### PR TITLE
Build docs with Gulp

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,2 @@
+node_modules/
+build/

--- a/README.md
+++ b/README.md
@@ -8,7 +8,7 @@ The root `apiary.apib` is still committed in this repository so apiary.io can re
 
 ## Branches
 
-This repository has, besides `master`, two important branches: [`v1`](https://github.com/teamleadercrm/api/tree/v1) and [`v2`](https://github.com/teamleadercrm/api/tree/v2). Following rules apply: 
+This repository has, besides `master`, two important branches: [`v1`](https://github.com/teamleadercrm/api/tree/v1) and [`v2`](https://github.com/teamleadercrm/api/tree/v2). Following rules apply:
 
 - `v1` documents the exisiting API (living in [teamleadercrm/core](https://github.com/teamleadercrm/core/tree/development/public_html/api)).
 - `v2` will document how we want a more modern API to look. We will implement those changes by changing [teamleadercrm/api-proxy](https://github.com/teamleadercrm/api-proxy).
@@ -18,21 +18,25 @@ This repository has, besides `master`, two important branches: [`v1`](https://gi
 
 ## Building the docs
 
-Install Hercule
+Install dependencies:
 
 ```bash
-$ npm install -g hercule
+npm install -g gulp-cli
+npm install
 ```
 
-After making the necessary changes, build the docs.
+Run `gulp build` to build. This will perform two operations:
 
-```bash
-hercule src/apiary.apic -o apiary.apib
-```
+1. Run `hercule` which "compiles" `src/apiary.apib` into `./apiary.apib`
+2. Run `docprint` to generate HTML from `./apiary.apib`
 
-### Automatically building the docs
+Once you built the docs, you can open `build/php/index.html` in your browser to preview.
 
-If you don't want to execute the above command manually every time you change the docs, add the following pre-commit hook:
+Run `gulp` when in development to automatically build when files change.
+
+### Automatically building the docs before commit
+
+If you want to make sure you don't forget to build the docs before you commit, add the following pre-commit hook:
 
 ```bash
 #!/bin/sh
@@ -48,18 +52,18 @@ git diff --cached --name-status | while read st file; do
 done
 ```
 
-The `pre-commit` hook file is placed in the `.git/hooks` folder. 
+The `pre-commit` hook file is placed in the `.git/hooks` folder.
 
-**Note:** If you exclusively use this documentation from the api-proxy as a git submodule, the hooks folder is in `../.git/modules/docs/hooks`. 
+**Note:** If you exclusively use this documentation from the api-proxy as a git submodule, the hooks folder is in `../.git/modules/docs/hooks`.
 
 ## Verifying docs
 
-You can lint the apib file to make sure it's valid. 
+You can lint the apib file to make sure it's valid.
 
-First install `apib-lint` 
+First install `apib-lint`
 
 ```bash
-$ npm install -g apib-lint 
+$ npm install -g apib-lint
 ```
 
 Then lint the file

--- a/gulpfile.js
+++ b/gulpfile.js
@@ -1,0 +1,51 @@
+var gulp = require('gulp');
+var watch = require('gulp-watch');
+var hercule = require('hercule');
+var through = require('through2');
+var docprint = require('docprint');
+
+gulp.task('default', ['watch']);
+
+gulp.task('watch', ['build'], function() {
+    return gulp.watch('src/*.apib', ['build'])
+});
+
+gulp.task('build', ['hercule'], function(cb) {
+    docprint({
+        filepath: './apiary.apib',
+        destination: './build'
+    });
+
+    cb();
+});
+
+gulp.task('hercule', function() {
+    return gulp.src('src/apiary.apib', {buffer: false})
+        .pipe(gulpHercule('src/apiary.apib'))
+        .pipe(gulp.dest('./'));
+
+    function gulpHercule(options) {
+        return through.obj(function(file, encoding, callback) {
+            if (file.isNull()) {
+                return callback(null, file);
+            }
+
+            if (file.isBuffer()) {
+                hercule.transcludeString(file.contents.toString(encoding), options, function(err, output) {
+                    if (err) {
+                        return callback(err, null)
+                    }
+                    file.contents = new Buffer(output);
+                    return callback(null, file);
+                });
+            }
+
+            if (file.isStream()) {
+                var transcluder = new hercule.TranscludeStream(options);
+                file.contents = file.contents.pipe(transcluder);
+
+                return callback(null, file);
+            }
+        });
+    };
+});

--- a/package.json
+++ b/package.json
@@ -1,0 +1,26 @@
+{
+  "name": "api",
+  "version": "1.0.0",
+  "description": "Teamleader API",
+  "main": "gulpfile.js",
+  "scripts": {
+    "test": "echo \"Error: no test specified\" && exit 1"
+  },
+  "repository": {
+    "type": "git",
+    "url": "git+https://github.com/teamleadercrm/api.git"
+  },
+  "author": "",
+  "license": "ISC",
+  "bugs": {
+    "url": "https://github.com/teamleadercrm/api/issues"
+  },
+  "homepage": "https://github.com/teamleadercrm/api#readme",
+  "devDependencies": {
+    "docprint": "^1.9.0",
+    "gulp": "^3.9.1",
+    "gulp-watch": "^4.3.11",
+    "hercule": "^4.0.1",
+    "through2": "^2.0.3"
+  }
+}


### PR DESCRIPTION
### Added
- `package.json` with dependencies needed to build the docs, including Hercule
- `gulpfile.js` with tasks to run Hercule and build HTML from `apiary.apib`

### Changed
- Updated `README.md `, replacing the previous instructions with instructions using Gulp

---
Q: Why?
A: I needed to preview the docs locally

In development, you can now run `gulp` which will watch files and build docs on changes. Open `build/php/index.html` in your browser to preview the docs.

**Note**: This is targeting the `v1` branch because the instructions should be on both `v1` and `master`.