### PR TITLE
Removed invoice_email from contacts

### DIFF
--- a/apiary.apib
+++ b/apiary.apib
@@ -161,7 +161,6 @@ Add a contact to Teamleader
         + email: `john@example.com` (string, required) - The email address of the new contact
         + salutation: `Mr` (string, optional)
         + email: `john@example.com` (string, required) - The email address of the new contact
-        + invoice_email: `invoicing@example.com` (string, optional)
         + phone: `1234567` (string, optional)
         + mobile: `7654321` (string, optional)
         + fax: `7654321` (string, optional)
@@ -198,7 +197,6 @@ Update a Teamleader contact
         + last_name: `Smith` (string) - The last name of the new contact
         + salutation: `Mr` (string, optional)
         + email: `john@example.com` (string, required) - The email address of the new contact
-        + invoice_email: `invoicing@example.com` (string, optional)
         + phone: `1234567` (string, optional)
         + mobile: `7654321` (string, optional)
         + fax: `7654321` (string, optional)
@@ -756,7 +754,6 @@ Register a webhook.
 + last_name: `Bachman` (string)
 + salutation: `Mr` (string)
 + email: `info@piedpiper.eu` (string)
-+ invoice_email: `invoicing@example.com` (string)
 + phone: `092980615` (string)
 + mobile: `0412121212` (string)
 + fax: `091234567` (string)

--- a/src/contacts.apib
+++ b/src/contacts.apib
@@ -47,7 +47,6 @@ Add a contact to Teamleader
         + email: `john@example.com` (string, required) - The email address of the new contact
         + salutation: `Mr` (string, optional)
         + email: `john@example.com` (string, required) - The email address of the new contact
-        + invoice_email: `invoicing@example.com` (string, optional)
         + phone: `1234567` (string, optional)
         + mobile: `7654321` (string, optional)
         + fax: `7654321` (string, optional)
@@ -84,7 +83,6 @@ Update a Teamleader contact
         + last_name: `Smith` (string) - The last name of the new contact
         + salutation: `Mr` (string, optional)
         + email: `john@example.com` (string, required) - The email address of the new contact
-        + invoice_email: `invoicing@example.com` (string, optional)
         + phone: `1234567` (string, optional)
         + mobile: `7654321` (string, optional)
         + fax: `7654321` (string, optional)

--- a/src/datastructures.apib
+++ b/src/datastructures.apib
@@ -66,7 +66,6 @@
 + last_name: `Bachman` (string)
 + salutation: `Mr` (string)
 + email: `info@piedpiper.eu` (string)
-+ invoice_email: `invoicing@example.com` (string)
 + phone: `092980615` (string)
 + mobile: `0412121212` (string)
 + fax: `091234567` (string)


### PR DESCRIPTION
### Changed
  - Removed the `invoice_email` from `contacts`

---
Contacts don't seem to have `invoice_email` only companies do.
The old api did support this on `addContact`, but that was due to that endpoint creating companies as wel.