### PR TITLE
V2: /agendaItem.list 

### DIFF
--- a/apiary.apib
+++ b/apiary.apib
@@ -112,6 +112,28 @@ Get a list of all tags
     + Attributes (object)
         + data: expo, upsell (array[string])
 
+## Agenda items [/agenda-items]
+
+### agendaItems.list [GET /agendaItems.list]
+
+Search agenda items
+
++ Request (application/json)
+
+    + Attributes (object)
+        + filter (object, required)
+            + type: `full-day` (enum[string], required) - Use this to filter by type
+                + Members
+                    + full-day
+            + employee_id: `1` (number, required) - Use this to filter by employee
+            + start_date: `2017-01-01` (string, required) - Format ISO 8601: yyyy-mm-dd
+            + end_date: `2017-01-01` (string, required) - Format ISO 8601: yyyy-mm-dd
+
++ Response 200 (application/json)
+
+    + Attributes (object)
+        + data (array[AgendaItem])
+
 ## Contacts [/contacts]
 
 ### contacts.list [GET /contacts.list]
@@ -702,6 +724,14 @@ Register a webhook.
 + zipcode: `94020` (string)
 + city: `Palo Alto` (string)
 + country: `US` (string)
+
+## AgendaItem (object)
++ id: `123` (number)
++ name: `Erlich Bachman's birthday` (string)
++ type: `full-day` (enum[string])
+    + Members
+        + full-day
++ date: `2017-05-16` (string)
 
 ## Company (object)
 + id: `123` (number)

--- a/src/apiary.apib
+++ b/src/apiary.apib
@@ -9,6 +9,8 @@ This is the Teamleader API v2 documentation.
 
 :[General](general.apib)
 
+:[Agenda items](agenda-items.apib)
+
 :[Contacts](contacts.apib)
 
 :[Companies](companies.apib)

--- a/src/datastructures.apib
+++ b/src/datastructures.apib
@@ -15,6 +15,14 @@
 + city: `Palo Alto` (string)
 + country: `US` (string)
 
+## AgendaItem (object)
++ id: `123` (number)
++ name: `Erlich Bachman's birthday` (string)
++ type: `full-day` (enum[string])
+    + Members
+        + full-day
++ date: `2017-05-16` (string)
+
 ## Company (object)
 + id: `123` (number)
 + name: `Pied Piper` (string)


### PR DESCRIPTION
This endpoint was created with [this PR of core in mind.](https://github.com/teamleadercrm/core/pull/2046) On the calendar we need to show all full-day events for an employee between two dates (one week most probably).

For now I defined (as discussed with @stivni) this like this:

`/agendaItems.list`
```
{
    filters: {
        type: full-day
        employee_id: 1
        start_date: 2017-01-10
        end_date: 2017-01-17
    }
}
```

All filters are required, because for now, that's the only case I need. I did put them as filters and not directly as parameters because this way we can make them optional in the future and remain backwards compatible