### PR TITLE
proposal for a simplified version of json api

### DIFF
--- a/specification-example.json
+++ b/specification-example.json
@@ -7,10 +7,11 @@
                 "amount": "100.000.000,00",
                 "currency": "EUR"
             },
+            "status": "draft",
             "buyer": {
                 "_type": "customer",
                 "id": "9",
-		"name": "John",
+		        "name": "John",
                 "_links": {
                     "self" : "http://api.teamleader.eu/customers.info?id=9"
 				}
@@ -18,12 +19,25 @@
             "invoice_items": {
                 "_items": [
                     { 
-                        "_type": "invoiceItem", 
-                        "id": "5",
+                        "linenumber": "1",
                         "_links": {},
                         "_actions": {
-                            "add" : "http://api.teamleader.eu/invoices.addItem?id=9&item=5&quantity=1",
-                            "remove" : "http://api.teamleader.eu/invoices.removeItem?id=9&item=5&quantity=1"
+                            "increment" : {
+                                "url": "http://api.teamleader.eu/invoices.addItem",
+                                "message": {
+                                    "id": 9,
+                                    "linenumber": 1,
+                                    "quantity": 1
+                                }
+                            },
+                            "remove" : {
+                                "url": "http://api.teamleader.eu/invoices.removeItem",
+                                "message": {
+                                    "id": 9,
+                                    "linenumber": 1,
+                                    "quantity": 1
+                                }
+                            }
                         }
                     }
                 ],
@@ -34,10 +48,34 @@
                 "self": "http://api.teamleader.eu/invoices.info?id=1"
             },
             "_actions": {
-                "addItem" : "http://api.teamleader.eu/invoices.addItem?id=9&item={id}&quantity={quantity}",
-                "removeItem" : "http://api.teamleader.eu/invoices.removeItem?id=9&item={id}&quantity={quantity}",
-                "remove" : "http://api.teamleader.eu/invoices.remove?id=9",
-                "book" : "http://api.teamleader.eu/invoices.book?id=9"
+                "addItem" : {
+                    "url": "http://api.teamleader.eu/invoices.addItem",
+                    "properties": {
+                        "id": "number[required]",
+                        "linenumber": "number[required]",
+                        "quantity": "number[required]"
+                    }
+                },
+                "removeItem" : {
+                    "url": "http://api.teamleader.eu/invoices.removeItem",
+                    "properties": {
+                        "id": "number[required]",
+                        "linenumber": "number[required]",
+                        "quantity": "number[required]"
+                    }
+                },
+                "remove" : {
+                    "url": "http://api.teamleader.eu/invoices.remove",
+                    "message": {
+                        "id": "9",
+                    }
+                },
+                "book" : {
+                    "url": "http://api.teamleader.eu/invoices.book",
+                    "message": {
+                        "id": "9",
+                    }
+                }
             }
         }
     ],
@@ -68,41 +106,57 @@
 {
     "_type": "invoice",
     "id": "1",
+    "status": "booked,
     "total": {
-	"amount": "100.000.000,00",
-	"currency": "EUR"
+        "amount": "100.000.000,00",
+        "currency": "EUR"
     },
     "buyer": {
-	"_type": "customer", 
-	"id": "9",
-	"name": "John",
-	"_links": {
-	    "self" : "http://api.teamleader.eu/customers.info?id=9"
-			}
+        "_type": "customer", 
+        "id": "9",
+        "name": "John",
+        "_links": {
+            "self" : "http://api.teamleader.eu/customers.info?id=9"
+        }
     },
     "invoice_items": {
-	"_items": [
-	    { 
-		"_type": "invoiceItem", 
-		"id": "5",
-		"_links": {},
-		"_actions": {
-		    "add" : "http://api.teamleader.eu/invoices.addItem?id=9&item=5&quantity=1",
-		    "remove" : "http://api.teamleader.eu/invoices.removeItem?id=9&item=5&quantity=1"
-		}
-	    }
-	],
-	"_links": {},
-	"_actions": {}
+        "_items": [
+            { 
+                "linenumber": "1",
+                "_links": {},
+                "_actions": {
+                    "increment" : {
+                        "url": "http://api.teamleader.eu/invoices.addItem",
+                        "message": {
+                            "id": 9,
+                            "linenumber": 1,
+                            "quantity": 1
+                        }
+                    },
+                    "remove" : {
+                        "url": "http://api.teamleader.eu/invoices.removeItem",
+                        "message": {
+                            "id": 9,
+                            "linenumber": 1,
+                            "quantity": 1
+                        }
+                    }
+                }
+	        }
+	    ],
+        "_links": {},
+        "_actions": {}
     },
     "_links": {
-	"self": "http://api.teamleader.eu/invoices.info?id=1"
+	    "self": "http://api.teamleader.eu/invoices.info?id=1"
     },
     "_actions": {
-	"addItem" : "http://api.teamleader.eu/invoices.addItem?id=9&item={id}&quantity={quantity}",
-	"removeItem" : "http://api.teamleader.eu/invoices.removeItem?id=9&item={id}&quantity={quantity}",
-	"remove" : "http://api.teamleader.eu/invoices.remove?id=9",
-	"book" : "http://api.teamleader.eu/invoices.book?id=9"
+        "credit" : {
+            "url": "http://api.teamleader.eu/invoices.credit",
+            "message": {
+                "id": "9",
+            }
+        }
     },
     "_meta": {},
     "_embedded": {

--- a/specification-example.json
+++ b/specification-example.json
@@ -1,5 +1,5 @@
 {
-  "_items": [{
+    "_items": [{
     "type": "invoice",
     "id": "1",
 		"total": {

--- a/specification-example.json
+++ b/specification-example.json
@@ -103,7 +103,7 @@
 	"removeItem" : "http://api.teamleader.eu/invoices.removeItem?id=9&item={id}&quantity={quantity}",
 	"remove" : "http://api.teamleader.eu/invoices.remove?id=9",
 	"book" : "http://api.teamleader.eu/invoices.book?id=9"
-    }
+    },
     "_meta": {},
     "_embedded": {
         "customer" : {

--- a/specification-example.json
+++ b/specification-example.json
@@ -8,7 +8,7 @@
 		},
     "buyer": {
         "type": "customer", 
-				"id": "9"
+				"id": "9",
 				"_links": {
 					"self" : "http://api.teamleader.eu/customers.info?id=9"
 				}
@@ -17,17 +17,17 @@
 			"_items": [
 				{ 
 					"type": "invoiceItem", 
-					"id": "5" 
+					"id": "5",
 					"_links": {},
 					"_actions": {
 						"add" : "http://api.teamleader.eu/invoices.addItem?id=9&item=5&quantity=1",
 						"remove" : "http://api.teamleader.eu/invoices.removeItem?id=9&item=5&quantity=1"
 					}
-				},
-			]
+				}
+			],
 			"_links": {},
-			"_actions": {},
-		}
+			"_actions": {}
+		},
     "_links": {
       "self": "http://api.teamleader.eu/invoices.info?id=1"
     },
@@ -35,7 +35,7 @@
 			"addItem" : "http://api.teamleader.eu/invoices.addItem?id=9&item={id}&quantity={quantity}",
 			"removeItem" : "http://api.teamleader.eu/invoices.removeItem?id=9&item={id}&quantity={quantity}",
 			"remove" : "http://api.teamleader.eu/invoices.remove?id=9",
-			"book" : "http://api.teamleader.eu/invoices.book?id=9",
+			"book" : "http://api.teamleader.eu/invoices.book?id=9"
 		}
   }],
 	"_links": {

--- a/specification-example.json
+++ b/specification-example.json
@@ -62,3 +62,56 @@
         }
     }
 }
+
+---
+
+{
+    "type": "invoice",
+    "id": "1",
+    "total": {
+	"amount": "100.000.000,00",
+	"currency": "EUR"
+    },
+    "buyer": {
+	"type": "customer", 
+	"id": "9",
+	"name": "John",
+	"_links": {
+	    "self" : "http://api.teamleader.eu/customers.info?id=9"
+			}
+    },
+    "invoice_items": {
+	"_items": [
+	    { 
+		"type": "invoiceItem", 
+		"id": "5",
+		"_links": {},
+		"_actions": {
+		    "add" : "http://api.teamleader.eu/invoices.addItem?id=9&item=5&quantity=1",
+		    "remove" : "http://api.teamleader.eu/invoices.removeItem?id=9&item=5&quantity=1"
+		}
+	    }
+	],
+	"_links": {},
+	"_actions": {}
+    },
+    "_links": {
+	"self": "http://api.teamleader.eu/invoices.info?id=1"
+    },
+    "_actions": {
+	"addItem" : "http://api.teamleader.eu/invoices.addItem?id=9&item={id}&quantity={quantity}",
+	"removeItem" : "http://api.teamleader.eu/invoices.removeItem?id=9&item={id}&quantity={quantity}",
+	"remove" : "http://api.teamleader.eu/invoices.remove?id=9",
+	"book" : "http://api.teamleader.eu/invoices.book?id=9"
+    }
+    "_meta": {},
+    "_embedded": {
+        "customer" : {
+            "9" : {
+                "type": "customer",
+                "id": 9,
+                "name": "John"
+            }
+        }
+    }
+}

--- a/specification-example.json
+++ b/specification-example.json
@@ -1,61 +1,63 @@
 {
-    "_items": [{
-    "type": "invoice",
-    "id": "1",
-		"total": {
-			"amount": "100.000.000,00",
-			"currency": "EUR"
-		},
-    "buyer": {
-        "type": "customer", 
-				"id": "9",
-				"_links": {
-					"self" : "http://api.teamleader.eu/customers.info?id=9"
+    "_items": [
+        {
+            "type": "invoice",
+            "id": "1",
+            "total": {
+                "amount": "100.000.000,00",
+                "currency": "EUR"
+            },
+            "buyer": {
+                "type": "customer", 
+                "id": "9",
+                "_links": {
+                    "self" : "http://api.teamleader.eu/customers.info?id=9"
 				}
-    },
-	 	"invoice_items": {
-			"_items": [
-				{ 
-					"type": "invoiceItem", 
-					"id": "5",
-					"_links": {},
-					"_actions": {
-						"add" : "http://api.teamleader.eu/invoices.addItem?id=9&item=5&quantity=1",
-						"remove" : "http://api.teamleader.eu/invoices.removeItem?id=9&item=5&quantity=1"
-					}
-				}
-			],
-			"_links": {},
-			"_actions": {}
-		},
+            },
+            "invoice_items": {
+                "_items": [
+                    { 
+                        "type": "invoiceItem", 
+                        "id": "5",
+                        "_links": {},
+                        "_actions": {
+                            "add" : "http://api.teamleader.eu/invoices.addItem?id=9&item=5&quantity=1",
+                            "remove" : "http://api.teamleader.eu/invoices.removeItem?id=9&item=5&quantity=1"
+                        }
+                    }
+                ],
+                "_links": {},
+                "_actions": {}
+            },
+            "_links": {
+                "self": "http://api.teamleader.eu/invoices.info?id=1"
+            },
+            "_actions": {
+                "addItem" : "http://api.teamleader.eu/invoices.addItem?id=9&item={id}&quantity={quantity}",
+                "removeItem" : "http://api.teamleader.eu/invoices.removeItem?id=9&item={id}&quantity={quantity}",
+                "remove" : "http://api.teamleader.eu/invoices.remove?id=9",
+                "book" : "http://api.teamleader.eu/invoices.book?id=9"
+            }
+        }
+    ],
     "_links": {
-      "self": "http://api.teamleader.eu/invoices.info?id=1"
+        "self": "http://api.teamleader.eu/invoices.list",
+        "next": "http://api.teamleader.eu/invoices.list?page[offset]=2",
+        "last": "http://api.teamleader.eu/invoices.list?page[offset]=10"
     },
-		"_actions": {
-			"addItem" : "http://api.teamleader.eu/invoices.addItem?id=9&item={id}&quantity={quantity}",
-			"removeItem" : "http://api.teamleader.eu/invoices.removeItem?id=9&item={id}&quantity={quantity}",
-			"remove" : "http://api.teamleader.eu/invoices.remove?id=9",
-			"book" : "http://api.teamleader.eu/invoices.book?id=9"
-		}
-  }],
-	"_links": {
-    "self": "http://api.teamleader.eu/invoices.list",
-    "next": "http://api.teamleader.eu/invoices.list?page[offset]=2",
-    "last": "http://api.teamleader.eu/invoices.list?page[offset]=10"
-  },
-	"_meta": {
-		"page": {
-			"count": 10,
-			"current": 1
-		}
-	},
-  "_embedded": {
-		"customer" : {
-			"9" : {
-				"type": "customer",
-				"id": 9,
-				"name": "John"
-			}
-		}
-	}
+    "_meta": {
+        "page": {
+            "count": 10,
+            "current": 1
+        }
+    },
+    "_embedded": {
+        "customer" : {
+            "9" : {
+                "type": "customer",
+                "id": 9,
+                "name": "John"
+            }
+        }
+    }
 }

--- a/specification-example.json
+++ b/specification-example.json
@@ -10,6 +10,7 @@
             "buyer": {
                 "type": "customer", 
                 "id": "9",
+		"name": "John",
                 "_links": {
                     "self" : "http://api.teamleader.eu/customers.info?id=9"
 				}

--- a/specification-example.json
+++ b/specification-example.json
@@ -1,0 +1,61 @@
+{
+  "_items": [{
+    "type": "invoice",
+    "id": "1",
+		"total": {
+			amount: "100.000.000,00",
+			currency: "EUR"
+		}
+    "buyer": {
+        "type": "customer", 
+				"id": "9"
+				"_links": {
+					"self" : "http://api.teamleader.eu/customers.info?id=9"
+				}
+    },
+	 	"invoice_items": {
+			"_items": [
+				{ 
+					"type": "invoiceItem", 
+					"id": "5" 
+					"_links": {},
+					"_actions": {
+						"add" : "http://api.teamleader.eu/invoices.addItem?id=9&item=5&quantity=1",
+						"remove" : "http://api.teamleader.eu/invoices.removeItem?id=9&item=5&quantity=1"
+					}
+				},
+			]
+			"_links": {},
+			"_actions": {},
+		}
+    "_links": {
+      "self": "http://api.teamleader.eu/invoices.info?id=1"
+    },
+		"_actions": {
+			"addItem" : "http://api.teamleader.eu/invoices.addItem?id=9&item={id}&quantity={quantity}",
+			"removeItem" : "http://api.teamleader.eu/invoices.removeItem?id=9&item={id}&quantity={quantity}",
+			"remove" : "http://api.teamleader.eu/invoices.remove?id=9",
+			"book" : "http://api.teamleader.eu/invoices.book?id=9",
+		}
+  }],
+	"_links": {
+    "self": "http://api.teamleader.eu/invoices.list",
+    "next": "http://api.teamleader.eu/invoices.list?page[offset]=2",
+    "last": "http://api.teamleader.eu/invoices.list?page[offset]=10"
+  },
+	"_meta": {
+		"page": {
+			"count": 10,
+			"current": 1
+		}
+	},
+  "_embedded": {
+		"customer" : {
+			"9" : {
+				"type": "customer",
+				"id": 9,
+				"name": "John"
+			}
+		}
+	}
+}

--- a/specification-example.json
+++ b/specification-example.json
@@ -1,14 +1,14 @@
 {
     "_items": [
         {
-            "type": "invoice",
+            "_type": "invoice",
             "id": "1",
             "total": {
                 "amount": "100.000.000,00",
                 "currency": "EUR"
             },
             "buyer": {
-                "type": "customer", 
+                "_type": "customer",
                 "id": "9",
 		"name": "John",
                 "_links": {
@@ -18,7 +18,7 @@
             "invoice_items": {
                 "_items": [
                     { 
-                        "type": "invoiceItem", 
+                        "_type": "invoiceItem", 
                         "id": "5",
                         "_links": {},
                         "_actions": {
@@ -55,7 +55,7 @@
     "_embedded": {
         "customer" : {
             "9" : {
-                "type": "customer",
+                "_type": "customer",
                 "id": 9,
                 "name": "John"
             }
@@ -66,14 +66,14 @@
 ---
 
 {
-    "type": "invoice",
+    "_type": "invoice",
     "id": "1",
     "total": {
 	"amount": "100.000.000,00",
 	"currency": "EUR"
     },
     "buyer": {
-	"type": "customer", 
+	"_type": "customer", 
 	"id": "9",
 	"name": "John",
 	"_links": {
@@ -83,7 +83,7 @@
     "invoice_items": {
 	"_items": [
 	    { 
-		"type": "invoiceItem", 
+		"_type": "invoiceItem", 
 		"id": "5",
 		"_links": {},
 		"_actions": {
@@ -108,7 +108,7 @@
     "_embedded": {
         "customer" : {
             "9" : {
-                "type": "customer",
+                "_type": "customer",
                 "id": 9,
                 "name": "John"
             }

--- a/specification-example.json
+++ b/specification-example.json
@@ -106,7 +106,7 @@
 {
     "_type": "invoice",
     "id": "1",
-    "status": "booked,
+    "status": "booked",
     "total": {
         "amount": "100.000.000,00",
         "currency": "EUR"
@@ -154,7 +154,7 @@
         "credit" : {
             "url": "http://api.teamleader.eu/invoices.credit",
             "message": {
-                "id": "9",
+                "id": "9"
             }
         }
     },

--- a/specification-example.json
+++ b/specification-example.json
@@ -3,9 +3,9 @@
     "type": "invoice",
     "id": "1",
 		"total": {
-			amount: "100.000.000,00",
-			currency: "EUR"
-		}
+			"amount": "100.000.000,00",
+			"currency": "EUR"
+		},
     "buyer": {
         "type": "customer", 
 				"id": "9"


### PR DESCRIPTION
As we think jsonapi is too bloated, but want to use some concepts...

Reasoning was:

- jsonapi assumes you have RESTful resources, which for us is not the case, so we can't follow it 100%
- jsonapi has a lot of nesting to make a separation between structural/semantical/transport properties and domain properties => we can avoid the nesting if we prefix structural/semantical/transport properties with `@` or `_` (as some other standards do)
- we want to be able to add metadata and HATEOAS links (I know it is a REST principle, but it can be applied to RPC too) if possible, also on collections => so they need to be objects with a property (named `_items`, `data`, ...)
- preferably, we want to hint users on the possible actions on a item or a collection (like in the SIREN specification)
- It is not possible in jsonapi, but we want to embed data of relationships in the response (inline, so it's easier to use), without changing the existing structure => relationships are always a(n) (collection with) object(s) with at least the id, but if embedded also the other properties
- if necessary, clients can ask to avoid duplicate embedded objects, by including them. This is possible in jsonapi, but not in an indexed way, which the frontenders thought was a pitty.