### PR TITLE
Rename company types to business types

### DIFF
--- a/apiary.apib
+++ b/apiary.apib
@@ -1202,7 +1202,7 @@ Get a list of all tags, sorted alphabetically
     + Attributes (object)
         + data : expo, upsell (array[string])
 
-### companyTypes.list [GET /companyTypes.list]
+### businessTypes.list [GET /businessTypes.list]
 
 Get the names of business types (legal structures) a company can have within a certain country, sorted alphabetically.
 

--- a/src/02-crm/settings.apib
+++ b/src/02-crm/settings.apib
@@ -16,7 +16,7 @@ Get a list of all tags, sorted alphabetically
     + Attributes (object)
         + data : expo, upsell (array[string])
 
-### companyTypes.list [GET /companyTypes.list]
+### businessTypes.list [GET /businessTypes.list]
 
 Get the names of business types (legal structures) a company can have within a certain country, sorted alphabetically.
 


### PR DESCRIPTION
Makes more sense because the company property is called `business_type`.