### PR TITLE
Remove the invoice_email from companies.update

### DIFF
--- a/apiary.apib
+++ b/apiary.apib
@@ -734,7 +734,6 @@ Update a company.
                         + primary
                         + invoicing
                 + email: `info@piedpiper.eu` (string, required, nullable)
-        + invoice_email: `invoicing@example.com` (string, required, nullable)
         + telephones (array[CompanyTelephone], required, nullable)
         + website: `http://example.com` (string, required, nullable)
         + addresses (array, required)

--- a/src/02-crm/companies.apib
+++ b/src/02-crm/companies.apib
@@ -162,7 +162,6 @@ Update a company.
                         + primary
                         + invoicing
                 + email: `info@piedpiper.eu` (string, required, nullable)
-        + invoice_email: `invoicing@example.com` (string, required, nullable)
         + telephones (array[CompanyTelephone], required, nullable)
         + website: `http://example.com` (string, required, nullable)
         + addresses (array, required)


### PR DESCRIPTION
This is included in the `emails` array with a type `invoicing`.