### PR TITLE
WritePrice object doesn't exist for now

### DIFF
--- a/apiary.apib
+++ b/apiary.apib
@@ -1168,7 +1168,11 @@ Update an invoice.
                     + (object)
                         + quantity: `3` (number, required)
                         + description: `An awesome product` (string, required)
-                        + unit_price (WritePrice, required)
+                        + unit_price (object)
+                            + Include Money
+                            + tax: `excluding` (enum[string])
+                                + Members
+                                    + excluding
                         + tax_id: `c0c03f1e-77e3-402c-a713-30ea1c585823` (string, required)
 
 + Response 204

--- a/src/04-invoicing/invoices.apib
+++ b/src/04-invoicing/invoices.apib
@@ -219,7 +219,11 @@ Update an invoice.
                     + (object)
                         + quantity: `3` (number, required)
                         + description: `An awesome product` (string, required)
-                        + unit_price (WritePrice, required)
+                        + unit_price (object)
+                            + Include Money
+                            + tax: `excluding` (enum[string])
+                                + Members
+                                    + excluding
                         + tax_id: `c0c03f1e-77e3-402c-a713-30ea1c585823` (string, required)
 
 + Response 204


### PR DESCRIPTION
Remove usage of WritePrice object since it doesn't exit in this version
Maybe later the unit_price should be moved to the datastructures 