### PR TITLE
Make 'on' required on /invoices.book

### DIFF
--- a/apiary.apib
+++ b/apiary.apib
@@ -1291,7 +1291,7 @@ Book a draft invoice.
 
     + Attributes (object)
         + id: `7abb325c-e063-42a4-8fb4-1b730759645a` (string, required)
-        + on: `2016-02-04` (string, optional) - If not provided, today will be used
+        + on: `2016-02-04` (string, required)
 
 + Response 204
 

--- a/src/04-invoicing/invoices.apib
+++ b/src/04-invoicing/invoices.apib
@@ -251,7 +251,7 @@ Book a draft invoice.
 
     + Attributes (object)
         + id: `7abb325c-e063-42a4-8fb4-1b730759645a` (string, required)
-        + on: `2016-02-04` (string, optional) - If not provided, today will be used
+        + on: `2016-02-04` (string, required)
 
 + Response 204
 


### PR DESCRIPTION
### Changed

- `on` is now a required field for `/invoices.book`