### PR TITLE
Force UTC when reading, accept all timezones when writing

### DIFF
--- a/GUIDELINES.md
+++ b/GUIDELINES.md
@@ -140,26 +140,25 @@ Example:
 
 ### Date and time
 
-Dates, times and datetimes returned must follow the `ISO8601` standard. Times and datetimes may include timezone information. In PHP this can be generated using `format('c')`.
+Dates, times and datetimes returned must follow the `ISO8601` standard. In PHP this can be generated using `format(DATE_ATOM)`.
 
 Date and datetime properties **MUST**:
 
  - The property name ends on `_on` for dates.
  - The property name ends on `_at` if they include time (time and datetime).
-
-And **MAY**:
-
- - Include timezone information
+ - Always be returned in `UTC` for consistency. It is the responsability of the client to offset the timezone for users.
 
 Examples:
 
 ```json
 {
   "contacted_on": "2017-10-13",
-  "updated_at": "2017-10-15T10:01:49+01:00",
+  "updated_at": "2017-10-15T10:01:49+00:00",
   "available_at": "11:00:00",
 }
 ```
+
+Writing datetime properties **MUST** accept every timezone.
 
 ### Money
 


### PR DESCRIPTION
This solves a big issue of inconsistency in the api endpoints.
We currently return datetime in whatever timezone, even mixing up multiple timezones in a single endpoint.
By returning everything in UTC we allow the client to do offsetting depending on localized timezone.