### PR TITLE
Fix warning 'no value(s) specified' with custom fields definition object

### DIFF
--- a/apiary.apib
+++ b/apiary.apib
@@ -530,7 +530,7 @@ Get details for a single contact.
             + updated_at: `2016-02-05T16:44:33+00:00` (string)
             + custom_fields (array)
                 + (object)
-                    + definition: (object)
+                    + definition (object)
                         + type: `customFieldDefinition` (string)
                         + id: `bf6765de-56eb-40ec-ad14-9096c5dc5fe1` (string)
                     + One Of

--- a/src/02-crm/contacts.apib
+++ b/src/02-crm/contacts.apib
@@ -120,7 +120,7 @@ Get details for a single contact.
             + updated_at: `2016-02-05T16:44:33+00:00` (string)
             + custom_fields (array)
                 + (object)
-                    + definition: (object)
+                    + definition (object)
                         + type: `customFieldDefinition` (string)
                         + id: `bf6765de-56eb-40ec-ad14-9096c5dc5fe1` (string)
                     + One Of


### PR DESCRIPTION
Fix `definition` object in custom fields in `contacts.apib`. This triggered a warning upon building.