### PR TITLE
Add work_type_id to events.create

### DIFF
--- a/apiary.apib
+++ b/apiary.apib
@@ -1359,6 +1359,7 @@ Create a new calendar event.
         + activity_type_id: `b0a9ace5-fe82-4827-9d90-fc52f2c93050` (string, required)
         + starts_at: `2016-02-04T16:00:00+00:00` (string, required)
         + ends_at: `2016-02-04T18:00:00+00:00` (string, required)
+        + work_type_id: `b37e2bc7-dea0-4fda-88e9-c092fb65667d` (string, optional)
         + attendees (array, optional)
             + (object)
                 + type: `user` (enum[string], required)

--- a/src/04-calendar/events.apib
+++ b/src/04-calendar/events.apib
@@ -133,6 +133,7 @@ Create a new calendar event.
         + activity_type_id: `b0a9ace5-fe82-4827-9d90-fc52f2c93050` (string, required)
         + starts_at: `2016-02-04T16:00:00+00:00` (string, required)
         + ends_at: `2016-02-04T18:00:00+00:00` (string, required)
+        + work_type_id: `b37e2bc7-dea0-4fda-88e9-c092fb65667d` (string, optional)
         + attendees (array, optional)
             + (object)
                 + type: `user` (enum[string], required)


### PR DESCRIPTION
This will only be used for events of type task for now, it's mandatory for those types of events