### PR TITLE
Add proposal for the deals.lose endpoint

### DIFF
--- a/apiary.apib
+++ b/apiary.apib
@@ -1209,6 +1209,19 @@ Move the deal to a different phase.
 
 + Response 204
 
+### deals.lose [POST /deals.lose]
+
+Mark a deal as lost.
+
++ Request (application/json;charset=utf-8)
+
+    + Attributes (object)
+        + id: `460df7b2-fe82-4c6c-b215-6d0a1bd3c742` (string, required)
+        + reason_id: `da4c902f-2ae5-4c1f-be6f-b50308aabc5c` (string, optional)
+        + extra_info: `Not ready for a change, decision postponed` (string, optional)
+
++ Response 204
+
 ## Deal Phases [/]
 
 ### dealPhases.list [GET /dealPhases.list]

--- a/src/03-deals/deals.apib
+++ b/src/03-deals/deals.apib
@@ -185,3 +185,16 @@ Move the deal to a different phase.
         + phase_id: `8776abee-d856-43c6-b98d-9ffc912e8b0b` (string, required)
 
 + Response 204
+
+### deals.lose [POST /deals.lose]
+
+Mark a deal as lost.
+
++ Request (application/json;charset=utf-8)
+
+    + Attributes (object)
+        + id: `460df7b2-fe82-4c6c-b215-6d0a1bd3c742` (string, required)
+        + reason_id: `da4c902f-2ae5-4c1f-be6f-b50308aabc5c` (string, optional)
+        + extra_info: `Not ready for a change, decision postponed` (string, optional)
+
++ Response 204


### PR DESCRIPTION
It allows you to optionally add a loss reason and an elaboration (just
like in the UI).

previous proposal was `.lost` instead of `.lose`, but we thought `.lose` is more consistent with other endpoints (actions in the imperative form). Open for discussion.