### PR TITLE
Add a related_status to the dealPhases.list endpoint

### DIFF
--- a/apiary.apib
+++ b/apiary.apib
@@ -1399,6 +1399,12 @@ Get a list of all phases a deal can go through, sorted by their order in the flo
             + (object)
                 + id: `21efc56e-1ba8-469d-926a-e89502591b47` (string)
                 + name: `New` (string)
+                + related_status: `new` (enum[string])
+                    + Members
+                        + new
+                        + won
+                        + lost
+                        + open
 
 ## Deal Sources [/dealSources]
 

--- a/src/03-deals/deal-phases.apib
+++ b/src/03-deals/deal-phases.apib
@@ -18,3 +18,9 @@ Get a list of all phases a deal can go through, sorted by their order in the flo
             + (object)
                 + id: `21efc56e-1ba8-469d-926a-e89502591b47` (string)
                 + name: `New` (string)
+                + related_status: `new` (enum[string])
+                    + Members
+                        + new
+                        + won
+                        + lost
+                        + open


### PR DESCRIPTION
This is needed because otherwise integrators don't know which phase is
related to a certain status.

An example: team mobile does a `deals.win` and want to know to which
phase id this will resolve. If they want to do it right now, they have
to refetch the deal using deals.info afterwards.