### PR TITLE
Add required scopes to API endpoints

### DIFF
--- a/apiary.apib
+++ b/apiary.apib
@@ -113,13 +113,17 @@ Common used status codes:
  - `429` - Too Many Requests, your client has reached the API rate limit
  - `500` - Internal Server Error, something went wrong on our end
 
-## OAuth 2
+## Authentication
+
+### OAuth 2
 
 OAuth 2 is an authorization framework that allows a user to grant limited access to data in a Teamleader account, without having to expose their credentials.
 
 To get access to the protected resources using our API, OAuth 2 uses access tokens. An access token is a string representing the granted permissions. Access tokens can be obtained after a user has completed the OAuth 2 authorization flow.
 
 Before starting, you will need to register your integration (an OAuth 2 client) on our [Marketplace](https://marketplace.teamleader.eu/build). Each registered integration is assigned a unique `client_id` and `client_secret`, which is used in the OAuth 2 authorization flow. Note that the `client_secret` key should not be shared or embedded in client side code.
+
+When you register an integration on our [Marketplace](https://marketplace.teamleader.eu), it is required to select all *scopes* your integration wants access to.
 
 For more detailed information about OAuth 2, we recommend reading [this article](https://auth0.com/docs/protocols/oauth2).
 

--- a/apiary.apib
+++ b/apiary.apib
@@ -257,6 +257,8 @@ The changelog can be found [here](https://github.com/teamleadercrm/api/blob/mast
 
 Departments are used to split quotations and invoices for different legal entities or within one organisation.
 
+*Required scopes: `departments`*
+
 ### departments.list [GET /departments.list]
 
 Get a list of departments.
@@ -308,6 +310,8 @@ Get details for a single department.
 ## Users [/users]
 
 Users are co-workers in a Teamleader account.
+
+*Required scopes: `users`*
 
 ### users.me [GET /users.me]
 
@@ -570,8 +574,9 @@ Get a list of all work types, sorted alphabetically (on their name).
 
 ## Contacts [/contacts]
 
-Contacts are physical entities who are added to your CRM database.
-Contacts might be linked to one or more companies.
+Contacts are physical entities who are added to your CRM database. Contacts might be linked to one or more companies.
+
+*Required scopes: `contacts`*
 
 ### contacts.list [GET /contacts.list]
 
@@ -855,6 +860,8 @@ Unlink a contact from a company.
 ## Companies [/companies]
 
 Companies are legal entities, usually linked to a VAT and/or local business number.
+
+*Required scopes: `companies`*
 
 ### companies.list [GET /companies.list]
 
@@ -1155,6 +1162,8 @@ Get a list of tags.
 
 ## Deals [/deals]
 
+*Required scopes: `deals`*
+
 ### deals.list [GET /deals.list]
 
 Get a list of deals.
@@ -1426,6 +1435,8 @@ Get a list of lost reasons for deals.
 
 ## Deal Phases [/]
 
+*Required scopes: `deals`*
+
 ### dealPhases.list [GET /dealPhases.list]
 
 Get a list of all phases a deal can go through, sorted by their order in the flow.
@@ -1446,6 +1457,8 @@ Get a list of all phases a deal can go through, sorted by their order in the flo
                 + name: `New` (string)
 
 ## Deal Sources [/dealSources]
+
+*Required scopes: `deals`*
 
 ### dealSources.list [GET /dealSources.list]
 
@@ -1472,6 +1485,8 @@ Get a list of all deal sources, sorted alphabetically (on name)
                 + name: `Referral` (string)
 
 ## Quotations [/quotations]
+
+*Required scopes: `quotations`*
 
 ### quotations.info [GET /quotations.info]
 
@@ -1521,6 +1536,8 @@ Get a quotation
 Calendar events are scheduled events in your calendar.
 A calendar event involves a particular activity type: a task, meeting or call.
 They can also be linked to one to-do.
+
+*Required scopes: `events`*
 
 ### events.list [GET /events.list]
 
@@ -1747,9 +1764,9 @@ Get a list of all activity types.
 
 ## Invoices [/invoices]
 
-Teamleader provides a whole set of endpoints to make it easy to develop integrations with invoices.
-New invoices are created in accordance with this flow: `invoice.draft` → `invoice.book`.
-Invoices can also be updated, deleted or credited.
+Teamleader provides a whole set of endpoints to make it easy to develop integrations with invoices. New invoices are created in accordance with this flow: `invoice.draft` → `invoice.book`. Invoices can also be updated, deleted or credited.
+
+*Required scopes: `invoices`*
 
 ### invoices.list [GET /invoices.list]
 
@@ -2059,7 +2076,9 @@ Register a payment for an invoice.
 
 + Response 204
 
-## Creditnotes [/creditNotes]
+## Credit Notes [/creditNotes]
+
+*Required scopes: `invoices`*
 
 ### creditNotes.list [GET /creditNotes.list]
 
@@ -2232,6 +2251,10 @@ Get a list of available tax rates.
                     + type: `department` (string)
                     + id: `182af0a8-3f68-409b-8941-cf8caf8f28a0` (string)
 
+## Payment Terms [/paymentTerms]
+
+*Required scopes: `invoices`*
+
 ### paymentTerms.list [GET /paymentTerms.list]
 
 Get a list of available payment terms.
@@ -2249,6 +2272,8 @@ Get a list of available payment terms.
 # Group Products
 
 ## Product Categories [/productCategories]
+
+*Required scopes: `products`*
 
 ### productCategories.list [GET /productCategories.list]
 
@@ -2280,6 +2305,8 @@ Get a list of product categories.
 
 Projects allow users to work together as a team on a single project.
 They comprise of one or more milestones, have one or more participants and are limited in time and budget.
+
+*Required scopes: `projects`*
 
 ### projects.list [GET /projects.list]
 
@@ -2487,6 +2514,8 @@ Update a participant's role for a project.
 
 Every projects consists of one or more milestones which are limited in time and budget.
 Budget is however not included in this endpoints (yet).
+
+*Required scopes: `projects`*
 
 ### milestones.list [GET /milestones.list]
 

--- a/apiary.apib
+++ b/apiary.apib
@@ -2257,8 +2257,6 @@ Get a list of available tax rates.
 
 ## Payment Terms [/paymentTerms]
 
-*Required scopes: `invoices`*
-
 ### paymentTerms.list [GET /paymentTerms.list]
 
 Get a list of available payment terms.

--- a/src/01-general/departments.apib
+++ b/src/01-general/departments.apib
@@ -2,6 +2,8 @@
 
 Departments are used to split quotations and invoices for different legal entities or within one organisation.
 
+*Required scopes: `departments`*
+
 ### departments.list [GET /departments.list]
 
 Get a list of departments.

--- a/src/01-general/users.apib
+++ b/src/01-general/users.apib
@@ -2,6 +2,8 @@
 
 Users are co-workers in a Teamleader account.
 
+*Required scopes: `users`*
+
 ### users.me [GET /users.me]
 
 Get the current authenticated user.

--- a/src/02-crm/companies.apib
+++ b/src/02-crm/companies.apib
@@ -2,6 +2,8 @@
 
 Companies are legal entities, usually linked to a VAT and/or local business number.
 
+*Required scopes: `companies`*
+
 ### companies.list [GET /companies.list]
 
 Get a list of companies.

--- a/src/02-crm/contacts.apib
+++ b/src/02-crm/contacts.apib
@@ -1,7 +1,8 @@
 ## Contacts [/contacts]
 
-Contacts are physical entities who are added to your CRM database.
-Contacts might be linked to one or more companies.
+Contacts are physical entities who are added to your CRM database. Contacts might be linked to one or more companies.
+
+*Required scopes: `contacts`*
 
 ### contacts.list [GET /contacts.list]
 

--- a/src/03-deals/deal-phases.apib
+++ b/src/03-deals/deal-phases.apib
@@ -1,5 +1,7 @@
 ## Deal Phases [/]
 
+*Required scopes: `deals`*
+
 ### dealPhases.list [GET /dealPhases.list]
 
 Get a list of all phases a deal can go through, sorted by their order in the flow.

--- a/src/03-deals/deal-sources.apib
+++ b/src/03-deals/deal-sources.apib
@@ -1,5 +1,7 @@
 ## Deal Sources [/dealSources]
 
+*Required scopes: `deals`*
+
 ### dealSources.list [GET /dealSources.list]
 
 Get a list of all deal sources, sorted alphabetically (on name)

--- a/src/03-deals/deals.apib
+++ b/src/03-deals/deals.apib
@@ -1,5 +1,7 @@
 ## Deals [/deals]
 
+*Required scopes: `deals`*
+
 ### deals.list [GET /deals.list]
 
 Get a list of deals.

--- a/src/03-deals/quotations.apib
+++ b/src/03-deals/quotations.apib
@@ -1,5 +1,7 @@
 ## Quotations [/quotations]
 
+*Required scopes: `quotations`*
+
 ### quotations.info [GET /quotations.info]
 
 Get a quotation

--- a/src/04-calendar/events.apib
+++ b/src/04-calendar/events.apib
@@ -4,6 +4,8 @@ Calendar events are scheduled events in your calendar.
 A calendar event involves a particular activity type: a task, meeting or call.
 They can also be linked to one to-do.
 
+*Required scopes: `events`*
+
 ### events.list [GET /events.list]
 
 Get a list of calendar events.

--- a/src/05-invoicing/credit-notes.apib
+++ b/src/05-invoicing/credit-notes.apib
@@ -1,4 +1,6 @@
-## Creditnotes [/creditNotes]
+## Credit Notes [/creditNotes]
+
+*Required scopes: `invoices`*
 
 ### creditNotes.list [GET /creditNotes.list]
 

--- a/src/05-invoicing/invoices.apib
+++ b/src/05-invoicing/invoices.apib
@@ -1,8 +1,8 @@
 ## Invoices [/invoices]
 
-Teamleader provides a whole set of endpoints to make it easy to develop integrations with invoices.
-New invoices are created in accordance with this flow: `invoice.draft` → `invoice.book`.
-Invoices can also be updated, deleted or credited.
+Teamleader provides a whole set of endpoints to make it easy to develop integrations with invoices. New invoices are created in accordance with this flow: `invoice.draft` → `invoice.book`. Invoices can also be updated, deleted or credited.
+
+*Required scopes: `invoices`*
 
 ### invoices.list [GET /invoices.list]
 

--- a/src/05-invoicing/payment-terms.apib
+++ b/src/05-invoicing/payment-terms.apib
@@ -1,3 +1,7 @@
+## Payment Terms [/paymentTerms]
+
+*Required scopes: `invoices`*
+
 ### paymentTerms.list [GET /paymentTerms.list]
 
 Get a list of available payment terms.

--- a/src/05-invoicing/payment-terms.apib
+++ b/src/05-invoicing/payment-terms.apib
@@ -1,7 +1,5 @@
 ## Payment Terms [/paymentTerms]
 
-*Required scopes: `invoices`*
-
 ### paymentTerms.list [GET /paymentTerms.list]
 
 Get a list of available payment terms.

--- a/src/06-products/product-categories.apib
+++ b/src/06-products/product-categories.apib
@@ -1,5 +1,7 @@
 ## Product Categories [/productCategories]
 
+*Required scopes: `products`*
+
 ### productCategories.list [GET /productCategories.list]
 
 Get a list of product categories.

--- a/src/07-projects/milestones.apib
+++ b/src/07-projects/milestones.apib
@@ -3,6 +3,8 @@
 Every projects consists of one or more milestones which are limited in time and budget.
 Budget is however not included in this endpoints (yet).
 
+*Required scopes: `projects`*
+
 ### milestones.list [GET /milestones.list]
 
 Get a list of project milestones.

--- a/src/07-projects/projects.apib
+++ b/src/07-projects/projects.apib
@@ -3,6 +3,8 @@
 Projects allow users to work together as a team on a single project.
 They comprise of one or more milestones, have one or more participants and are limited in time and budget.
 
+*Required scopes: `projects`*
+
 ### projects.list [GET /projects.list]
 
 Get a list of projects.

--- a/src/apiary.apib
+++ b/src/apiary.apib
@@ -5,7 +5,7 @@ HOST: https://api.teamleader.eu
 
 :[Introduction](introduction.apib)
 
-:[OAuth2](oauth2.apib)
+:[Authentication](authentication.apib)
 
 :[Changelog](changelog.apib)
 

--- a/src/authentication.apib
+++ b/src/authentication.apib
@@ -1,10 +1,14 @@
-## OAuth 2
+## Authentication
+
+### OAuth 2
 
 OAuth 2 is an authorization framework that allows a user to grant limited access to data in a Teamleader account, without having to expose their credentials.
 
 To get access to the protected resources using our API, OAuth 2 uses access tokens. An access token is a string representing the granted permissions. Access tokens can be obtained after a user has completed the OAuth 2 authorization flow.
 
 Before starting, you will need to register your integration (an OAuth 2 client) on our [Marketplace](https://marketplace.teamleader.eu/build). Each registered integration is assigned a unique `client_id` and `client_secret`, which is used in the OAuth 2 authorization flow. Note that the `client_secret` key should not be shared or embedded in client side code.
+
+When you register an integration on our [Marketplace](https://marketplace.teamleader.eu), it is required to select all *scopes* your integration wants access to.
 
 For more detailed information about OAuth 2, we recommend reading [this article](https://auth0.com/docs/protocols/oauth2).
 


### PR DESCRIPTION
The API documentation is missing information about required scopes for our endpoints.