### PR TITLE
Change invoice.download response

### DIFF
--- a/apiary.apib
+++ b/apiary.apib
@@ -1957,11 +1957,12 @@ Download an invoice in a specific format.
             + Members
                 + pdf
 
-+ Response 307 (application/json;charset=utf-8)
++ Response 200 (application/json;charset=utf-8)
 
-    + Headers
-
-              Location: The url of the downloadable file. This will remain valid for 30 seconds.
+    + Attributes (object)
+        + data (object)
+            + location: `https://cdn.teamleader.eu/file` (string) - A temporary url where the requested file can be downloaded from
+            + expires: `2018-02-05T16:44:33+00:00` (string) - When the temporary download link expires
 
 ### invoices.draft [POST /invoices.draft]
 

--- a/src/05-invoicing/invoices.apib
+++ b/src/05-invoicing/invoices.apib
@@ -173,11 +173,12 @@ Download an invoice in a specific format.
             + Members
                 + pdf
 
-+ Response 307 (application/json;charset=utf-8)
++ Response 200 (application/json;charset=utf-8)
 
-    + Headers
-
-              Location: The url of the downloadable file. This will remain valid for 30 seconds.
+    + Attributes (object)
+        + data (object)
+            + location: `https://cdn.teamleader.eu/file` (string) - A temporary url where the requested file can be downloaded from
+            + expires: `2018-02-05T16:44:33+00:00` (string) - When the temporary download link expires
 
 ### invoices.draft [POST /invoices.draft]
 


### PR DESCRIPTION
HTTP clients that automatically follow the `Location` header, would fail to download the actual file because the Teamleader `Authorization` header is also sent to the download location.

This proposal returns the download location in a regular `200` response, with additional information about the expiration time of the link.