### PR TITLE
Improve documentation for contact/company addressee

### DIFF
--- a/apiary.apib
+++ b/apiary.apib
@@ -676,17 +676,13 @@ Get details for a single contact.
             + website: `https://piedpiper.com` (string)
             + addresses (array)
                 + (object)
-                    + One Of
-                        + Properties
-                            + type: `primary` (string)
-                            + address (Address)
-                        + Properties
-                            + type: `invoicing` (enum[string])
-                                + Members
-                                    + invoicing
-                                    + delivery
-                                    + visiting
-                            + address (Addressee)
+                    + type: `invoicing` (enum[string])
+                        + Members
+                            + primary
+                            + invoicing
+                            + delivery
+                            + visiting
+                    + address (Addressee) - Primary addresses can not contain an addressee
             + gender: `male` (enum[string])
                 + Members
                     + male
@@ -731,17 +727,13 @@ Add a new contact.
         + website: `http://example.com` (string, optional)
         + addresses (array, optional)
             + (object)
-                + One Of
-                    + Properties
-                        + type: `primary` (string, required)
-                        + address (Address, required) - Primary addresses can not contain an addressee
-                    + Properties
-                        + type: `invoicing` (enum[string], required)
-                            + Members
-                                + invoicing
-                                + delivery
-                                + visiting
-                        + address (Addressee, required)
+                + type: `invoicing` (enum[string], required)
+                    + Members
+                        + primary
+                        + invoicing
+                        + delivery
+                        + visiting
+                + address (Addressee, required) - Primary addresses can not contain an addressee
         + language: `en` (string, optional)
         + gender: `male` (enum[string], optional)
             + Members
@@ -782,17 +774,13 @@ Update a contact.
         + website: `http://example.com` (string, optional, nullable)
         + addresses (array, optional)
             + (object)
-                + One Of
-                    + Properties
-                        + type: `primary` (string, required)
-                        + address (Address, required) - Primary addresses can not contain an addressee
-                    + Properties
-                        + type: `invoicing` (enum[string], required)
-                            + Members
-                                + invoicing
-                                + delivery
-                                + visiting
-                        + address (Addressee, required)
+                + type: `invoicing` (enum[string], required)
+                    + Members
+                        + primary
+                        + invoicing
+                        + delivery
+                        + visiting
+                + address (Addressee, required) - Primary addresses can not contain an addressee
         + language: `en` (string, optional)
         + gender: `male` (enum[string], optional, nullable)
             + Members
@@ -969,17 +957,13 @@ Get details for a single company.
             + website: `https://piedpiper.com` (string)
             + addresses (array)
                 + (object)
-                    + One Of
-                        + Properties
-                            + type: `primary` (string)
-                            + address (Address)
-                        + Properties
-                            + type: `invoicing` (enum[string])
-                                + Members
-                                    + invoicing
-                                    + delivery
-                                    + visiting
-                            + address (Addressee)
+                    + type: `invoicing` (enum[string])
+                        + Members
+                            + primary
+                            + invoicing
+                            + delivery
+                            + visiting
+                    + address (Addressee) - Primary addresses can not contain an addressee
             + iban: `BE12123412341234` (string)
             + bic: `BICBANK` (string)
             + language: `nl` (string)
@@ -1017,17 +1001,13 @@ Add a new company.
         + website: `http://example.com` (string, optional)
         + addresses (array, optional)
             + (object)
-                + One Of
-                    + Properties
-                        + type: `primary` (string, required)
-                        + address (Address, required) - Primary addresses can not contain an addressee
-                    + Properties
-                        + type: `invoicing` (enum[string], required)
-                            + Members
-                                + invoicing
-                                + delivery
-                                + visiting
-                        + address (Addressee, required)
+                + type: `invoicing` (enum[string], required)
+                    + Members
+                        + primary
+                        + invoicing
+                        + delivery
+                        + visiting
+                + address (Addressee, required) - Primary addresses can not contain an addressee
         + iban: `BE12 1234 1234 1234` (string)
         + bic: `BICBANK` (string, optional)
         + language: `en` (string, optional)
@@ -1066,17 +1046,13 @@ Update a company.
         + website: `http://example.com` (string, optional)
         + addresses (array, optional)
             + (object)
-                + One Of
-                    + Properties
-                        + type: `primary` (string, required)
-                        + address (Address, required) - Primary addresses can not contain an addressee
-                    + Properties
-                        + type: `invoicing` (enum[string], required)
-                            + Members
-                                + invoicing
-                                + delivery
-                                + visiting
-                        + address (Addressee, required)
+                + type: `invoicing` (enum[string], required)
+                    + Members
+                        + primary
+                        + invoicing
+                        + delivery
+                        + visiting
+                + address (Addressee, required) - Primary addresses can not contain an addressee
         + iban: `BE12 1234 1234 1234` (string, optional, nullable)
         + bic: `BICBANK` (string, optional, nullable)
         + language: `en` (string, optional, nullable)

--- a/src/02-crm/companies.apib
+++ b/src/02-crm/companies.apib
@@ -100,17 +100,13 @@ Get details for a single company.
             + website: `https://piedpiper.com` (string)
             + addresses (array)
                 + (object)
-                    + One Of
-                        + Properties
-                            + type: `primary` (string)
-                            + address (Address)
-                        + Properties
-                            + type: `invoicing` (enum[string])
-                                + Members
-                                    + invoicing
-                                    + delivery
-                                    + visiting
-                            + address (Addressee)
+                    + type: `invoicing` (enum[string])
+                        + Members
+                            + primary
+                            + invoicing
+                            + delivery
+                            + visiting
+                    + address (Addressee) - Primary addresses can not contain an addressee
             + iban: `BE12123412341234` (string)
             + bic: `BICBANK` (string)
             + language: `nl` (string)
@@ -148,17 +144,13 @@ Add a new company.
         + website: `http://example.com` (string, optional)
         + addresses (array, optional)
             + (object)
-                + One Of
-                    + Properties
-                        + type: `primary` (string, required)
-                        + address (Address, required) - Primary addresses can not contain an addressee
-                    + Properties
-                        + type: `invoicing` (enum[string], required)
-                            + Members
-                                + invoicing
-                                + delivery
-                                + visiting
-                        + address (Addressee, required)
+                + type: `invoicing` (enum[string], required)
+                    + Members
+                        + primary
+                        + invoicing
+                        + delivery
+                        + visiting
+                + address (Addressee, required) - Primary addresses can not contain an addressee
         + iban: `BE12 1234 1234 1234` (string)
         + bic: `BICBANK` (string, optional)
         + language: `en` (string, optional)
@@ -197,17 +189,13 @@ Update a company.
         + website: `http://example.com` (string, optional)
         + addresses (array, optional)
             + (object)
-                + One Of
-                    + Properties
-                        + type: `primary` (string, required)
-                        + address (Address, required) - Primary addresses can not contain an addressee
-                    + Properties
-                        + type: `invoicing` (enum[string], required)
-                            + Members
-                                + invoicing
-                                + delivery
-                                + visiting
-                        + address (Addressee, required)
+                + type: `invoicing` (enum[string], required)
+                    + Members
+                        + primary
+                        + invoicing
+                        + delivery
+                        + visiting
+                + address (Addressee, required) - Primary addresses can not contain an addressee
         + iban: `BE12 1234 1234 1234` (string, optional, nullable)
         + bic: `BICBANK` (string, optional, nullable)
         + language: `en` (string, optional, nullable)

--- a/src/02-crm/contacts.apib
+++ b/src/02-crm/contacts.apib
@@ -95,17 +95,13 @@ Get details for a single contact.
             + website: `https://piedpiper.com` (string)
             + addresses (array)
                 + (object)
-                    + One Of
-                        + Properties
-                            + type: `primary` (string)
-                            + address (Address)
-                        + Properties
-                            + type: `invoicing` (enum[string])
-                                + Members
-                                    + invoicing
-                                    + delivery
-                                    + visiting
-                            + address (Addressee)
+                    + type: `invoicing` (enum[string])
+                        + Members
+                            + primary
+                            + invoicing
+                            + delivery
+                            + visiting
+                    + address (Addressee) - Primary addresses can not contain an addressee
             + gender: `male` (enum[string])
                 + Members
                     + male
@@ -150,17 +146,13 @@ Add a new contact.
         + website: `http://example.com` (string, optional)
         + addresses (array, optional)
             + (object)
-                + One Of
-                    + Properties
-                        + type: `primary` (string, required)
-                        + address (Address, required) - Primary addresses can not contain an addressee
-                    + Properties
-                        + type: `invoicing` (enum[string], required)
-                            + Members
-                                + invoicing
-                                + delivery
-                                + visiting
-                        + address (Addressee, required)
+                + type: `invoicing` (enum[string], required)
+                    + Members
+                        + primary
+                        + invoicing
+                        + delivery
+                        + visiting
+                + address (Addressee, required) - Primary addresses can not contain an addressee
         + language: `en` (string, optional)
         + gender: `male` (enum[string], optional)
             + Members
@@ -201,17 +193,13 @@ Update a contact.
         + website: `http://example.com` (string, optional, nullable)
         + addresses (array, optional)
             + (object)
-                + One Of
-                    + Properties
-                        + type: `primary` (string, required)
-                        + address (Address, required) - Primary addresses can not contain an addressee
-                    + Properties
-                        + type: `invoicing` (enum[string], required)
-                            + Members
-                                + invoicing
-                                + delivery
-                                + visiting
-                        + address (Addressee, required)
+                + type: `invoicing` (enum[string], required)
+                    + Members
+                        + primary
+                        + invoicing
+                        + delivery
+                        + visiting
+                + address (Addressee, required) - Primary addresses can not contain an addressee
         + language: `en` (string, optional)
         + gender: `male` (enum[string], optional, nullable)
             + Members


### PR DESCRIPTION
Currently our documentation is not showing the details of an address/addressee data structure for CRM endpoints:

![screenshot 2018-06-04 10 02 42](https://user-images.githubusercontent.com/194377/40905515-6fb2b822-67de-11e8-8261-6174b4a5b4f3.png)

I'm reverting this `One Of` change, but changed the documentation example to an invoicing address which can have an addressee (was primary before).