### PR TITLE
Add missing colon to fix parsing

### DIFF
--- a/apiary.apib
+++ b/apiary.apib
@@ -1980,7 +1980,7 @@ Draft a new invoice.
                 + id: `ebafa4c5-fa8a-4409-92e5-1b192243372f` (string)
             + for_attention_of (object, optional)
                 + One Of
-                    + name `Finance Dept.` (string, required)
+                    + name: `Finance Dept.` (string, required)
                     + contact_id: `417a2231-c3c7-4e1c-a6bb-1b014836ca60` (string, required)
         + department_id: `cef01135-7e51-4f6f-a6eb-6e5e5a885ac7` (string, required)
         + payment_term (PaymentTerm, required)

--- a/src/05-invoicing/invoices.apib
+++ b/src/05-invoicing/invoices.apib
@@ -196,7 +196,7 @@ Draft a new invoice.
                 + id: `ebafa4c5-fa8a-4409-92e5-1b192243372f` (string)
             + for_attention_of (object, optional)
                 + One Of
-                    + name `Finance Dept.` (string, required)
+                    + name: `Finance Dept.` (string, required)
                     + contact_id: `417a2231-c3c7-4e1c-a6bb-1b014836ca60` (string, required)
         + department_id: `cef01135-7e51-4f6f-a6eb-6e5e5a885ac7` (string, required)
         + payment_term (PaymentTerm, required)


### PR DESCRIPTION
### Fixed
- small parsing issue in `/invoices.draft` documentation