### PR TITLE
Add optional opted_in_for_mailings to companies.add

### DIFF
--- a/apiary.apib
+++ b/apiary.apib
@@ -1015,6 +1015,7 @@ Add a new company.
         + remarks: `Met at expo` (string, optional)
         + tags: prospect, expo (array[string], optional)
         + custom_fields (array[CustomFieldValue], optional)
+        + opted_in_for_mailings: false (boolean, optional)
 
 + Response 201 (application/json;charset=utf-8)
 

--- a/src/02-crm/companies.apib
+++ b/src/02-crm/companies.apib
@@ -158,6 +158,7 @@ Add a new company.
         + remarks: `Met at expo` (string, optional)
         + tags: prospect, expo (array[string], optional)
         + custom_fields (array[CustomFieldValue], optional)
+        + opted_in_for_mailings: false (boolean, optional)
 
 + Response 201 (application/json;charset=utf-8)
 


### PR DESCRIPTION
### Added

- optional `opted_in_for_mailings` for `companies.add`

---

Implementation: https://github.com/teamleadercrm/core/pull/5463
Tests: https://github.com/teamleadercrm/api-tests/pull/246