### PR TITLE
Don't allow tracking directly on a project for now

### DIFF
--- a/apiary.apib
+++ b/apiary.apib
@@ -2695,13 +2695,12 @@ Get a list of tracked time.
                 + duration: 3600 (number) - In seconds
                 + description: `Timer description` (string)
                 + subject (object)
-                    + type: `project` (enum[string])
+                    + type: `milestone` (enum[string])
                         + Members
                             + company
                             + contact
                             + event
                             + todo
-                            + project
                             + milestone
                             + ticket
                     + id: `58f5b799-51c4-4eb9-8308-b1aa02e0a873` (string)
@@ -2732,13 +2731,12 @@ Get information about tracked time.
             + duration: 3600 (number) - In seconds
             + description: `Timer description` (string)
             + subject (object)
-                + type: `project` (enum[string])
+                + type: `milestone` (enum[string])
                     + Members
                         + company
                         + contact
                         + event
                         + todo
-                        + project
                         + milestone
                         + ticket
                 + id: `5883723a-b5aa-4c9d-a02b-ec0dd25f6ca2` (string)
@@ -2757,13 +2755,12 @@ Add tracked time.
                 + duration: 3600 (number, required) - In seconds
         + description (string, optional)
         + subject (object, optional)
-            + type: `project` (enum[string], required)
+            + type: `milestone` (enum[string], required)
                 + Members
                     + company
                     + contact
                     + event
                     + todo
-                    + project
                     + milestone
                     + ticket
             + id: `b40ea20d-4ae5-4a56-be12-03766ecaefae` (string, required)
@@ -2790,13 +2787,12 @@ Update tracked time.
                 + duration: 3600 (number, required) - In seconds
         + description (string, optional, nullable)
         + subject (object, optional, nullable)
-            + type: `project` (enum[string], required)
+            + type: `milestone` (enum[string], required)
                 + Members
                     + company
                     + contact
                     + event
                     + todo
-                    + project
                     + milestone
                     + ticket
             + id: `88f14220-55d3-4ca6-802b-425e2f53c850` (string, required)
@@ -2842,13 +2838,12 @@ Get the current running timer.
             + started_at: `2017-04-26T10:01:49+00:00` (string)
             + description: `Timer description` (string)
             + subject (object)
-                + type: `project` (enum[string])
+                + type: `milestone` (enum[string])
                     + Members
                         + company
                         + contact
                         + event
                         + todo
-                        + project
                         + milestone
                         + ticket
                 + id: `31931bc9-4ae8-4c50-ba8d-9ea88498c1c1` (string)
@@ -2864,13 +2859,12 @@ Start a new timer.
         + started_at: `2017-04-26T10:01:49+00:00` (string, optional) - If not provided, current time will be used
         + description (string, optional)
         + subject (object, optional)
-            + type: `project` (enum[string], required)
+            + type: `milestone` (enum[string], required)
                 + Members
                     + company
                     + contact
                     + event
                     + todo
-                    + project
                     + milestone
                     + ticket
             + id: `29ff471c-7d8f-40d5-8c95-9a9cab841e65` (string, required)

--- a/src/06-time-tracking/time-tracking.apib
+++ b/src/06-time-tracking/time-tracking.apib
@@ -51,7 +51,6 @@ Get a list of tracked time.
                             + contact
                             + event
                             + todo
-                            + project
                             + milestone
                             + ticket
                     + id: `58f5b799-51c4-4eb9-8308-b1aa02e0a873` (string)

--- a/src/06-time-tracking/time-tracking.apib
+++ b/src/06-time-tracking/time-tracking.apib
@@ -45,7 +45,7 @@ Get a list of tracked time.
                 + duration: 3600 (number) - In seconds
                 + description: `Timer description` (string)
                 + subject (object)
-                    + type: `project` (enum[string])
+                    + type: `milestone` (enum[string])
                         + Members
                             + company
                             + contact
@@ -81,13 +81,12 @@ Get information about tracked time.
             + duration: 3600 (number) - In seconds
             + description: `Timer description` (string)
             + subject (object)
-                + type: `project` (enum[string])
+                + type: `milestone` (enum[string])
                     + Members
                         + company
                         + contact
                         + event
                         + todo
-                        + project
                         + milestone
                         + ticket
                 + id: `5883723a-b5aa-4c9d-a02b-ec0dd25f6ca2` (string)
@@ -106,13 +105,12 @@ Add tracked time.
                 + duration: 3600 (number, required) - In seconds
         + description (string, optional)
         + subject (object, optional)
-            + type: `project` (enum[string], required)
+            + type: `milestone` (enum[string], required)
                 + Members
                     + company
                     + contact
                     + event
                     + todo
-                    + project
                     + milestone
                     + ticket
             + id: `b40ea20d-4ae5-4a56-be12-03766ecaefae` (string, required)
@@ -139,13 +137,12 @@ Update tracked time.
                 + duration: 3600 (number, required) - In seconds
         + description (string, optional, nullable)
         + subject (object, optional, nullable)
-            + type: `project` (enum[string], required)
+            + type: `milestone` (enum[string], required)
                 + Members
                     + company
                     + contact
                     + event
                     + todo
-                    + project
                     + milestone
                     + ticket
             + id: `88f14220-55d3-4ca6-802b-425e2f53c850` (string, required)

--- a/src/06-time-tracking/timers.apib
+++ b/src/06-time-tracking/timers.apib
@@ -20,13 +20,12 @@ Get the current running timer.
             + started_at: `2017-04-26T10:01:49+00:00` (string)
             + description: `Timer description` (string)
             + subject (object)
-                + type: `project` (enum[string])
+                + type: `milestone` (enum[string])
                     + Members
                         + company
                         + contact
                         + event
                         + todo
-                        + project
                         + milestone
                         + ticket
                 + id: `31931bc9-4ae8-4c50-ba8d-9ea88498c1c1` (string)
@@ -42,13 +41,12 @@ Start a new timer.
         + started_at: `2017-04-26T10:01:49+00:00` (string, optional) - If not provided, current time will be used
         + description (string, optional)
         + subject (object, optional)
-            + type: `project` (enum[string], required)
+            + type: `milestone` (enum[string], required)
                 + Members
                     + company
                     + contact
                     + event
                     + todo
-                    + project
                     + milestone
                     + ticket
             + id: `29ff471c-7d8f-40d5-8c95-9a9cab841e65` (string, required)


### PR DESCRIPTION
All time tracking related code expects trackings on a project to also
have a milestone selected. Since we can't be sure on which milestone a
time tracking belongs while tracking on a contact, it doesn't make sense
to support it.

It's a lot more logical to just require a milestone to be selected if
you time track on a project.