### PR TITLE
CreditNote Download endpoint

### DIFF
--- a/apiary.apib
+++ b/apiary.apib
@@ -1941,8 +1941,8 @@ Download an invoice in a specific format.
 
     + Attributes (object)
         + data (object)
-            + location: `https://cdn.teamleader.eu/file` (string) - A temporary url from where the requested file can be downloaded
-            + expires: `2018-02-05T16:44:33+00:00` (string) - When the temporary download link expires
+            + location: `https://cdn.teamleader.eu/file` (string) - A temporary url where the requested file can be downloaded
+            + expires: `2018-02-05T16:44:33+00:00` (string) - Expiration time of the temporary download link
 
 ### invoices.draft [POST /invoices.draft]
 
@@ -2248,8 +2248,8 @@ Download a credit note in a specific format.
 
     + Attributes (object)
         + data (object)
-            + location: `https://cdn.teamleader.eu/file` (string) - A temporary url from where the requested file can be downloaded
-            + expires: `2018-02-05T16:44:33+00:00` (string) - When the temporary download link expires
+            + location: `https://cdn.teamleader.eu/file` (string) - A temporary url where the requested file can be downloaded
+            + expires: `2018-02-05T16:44:33+00:00` (string) - Expiration time of the temporary download link
 
 ## Tax Rates [/taxRates]
 

--- a/apiary.apib
+++ b/apiary.apib
@@ -2232,6 +2232,25 @@ Get details for a single credit note
                 + created_at: `2016-02-04T16:44:33+00:00` (string)
                 + updated_at: `2016-02-05T16:44:33+00:00` (string)
 
+### creditNotes.download [POST /creditNotes.download]
+
+Download a credit note in a specific format.
+
++ Request (application/json;charset=utf-8)
+
+    + Attributes (object)
+        + id: `d885e5d5-bacb-4607-bde9-abc4a04a901b` (string, required)
+        + format: `pdf` (enum[string], required)
+            + Members
+                + pdf
+
++ Response 200 (application/json;charset=utf-8)
+
+    + Attributes (object)
+        + data (object)
+            + location: `https://cdn.teamleader.eu/file` (string) - A temporary url where the requested file can be downloaded from
+            + expires: `2018-02-05T16:44:33+00:00` (string) - When the temporary download link expires
+
 ## Tax Rates [/taxRates]
 
 Tax rates provide an overview of different taxation rates used to bill customers. Teamleader provides a default list of tax rates based on the country of residence of the company that’s using Teamleader. The end user also has the option to add additional tax rates.

--- a/apiary.apib
+++ b/apiary.apib
@@ -1941,7 +1941,7 @@ Download an invoice in a specific format.
 
     + Attributes (object)
         + data (object)
-            + location: `https://cdn.teamleader.eu/file` (string) - A temporary url where the requested file can be downloaded from
+            + location: `https://cdn.teamleader.eu/file` (string) - A temporary url from where the requested file can be downloaded
             + expires: `2018-02-05T16:44:33+00:00` (string) - When the temporary download link expires
 
 ### invoices.draft [POST /invoices.draft]
@@ -2248,7 +2248,7 @@ Download a credit note in a specific format.
 
     + Attributes (object)
         + data (object)
-            + location: `https://cdn.teamleader.eu/file` (string) - A temporary url where the requested file can be downloaded from
+            + location: `https://cdn.teamleader.eu/file` (string) - A temporary url from where the requested file can be downloaded
             + expires: `2018-02-05T16:44:33+00:00` (string) - When the temporary download link expires
 
 ## Tax Rates [/taxRates]

--- a/src/05-invoicing/credit-notes.apib
+++ b/src/05-invoicing/credit-notes.apib
@@ -150,5 +150,5 @@ Download a credit note in a specific format.
 
     + Attributes (object)
         + data (object)
-            + location: `https://cdn.teamleader.eu/file` (string) - A temporary url where the requested file can be downloaded from
+            + location: `https://cdn.teamleader.eu/file` (string) - A temporary url from where the requested file can be downloaded
             + expires: `2018-02-05T16:44:33+00:00` (string) - When the temporary download link expires

--- a/src/05-invoicing/credit-notes.apib
+++ b/src/05-invoicing/credit-notes.apib
@@ -150,5 +150,5 @@ Download a credit note in a specific format.
 
     + Attributes (object)
         + data (object)
-            + location: `https://cdn.teamleader.eu/file` (string) - A temporary url from where the requested file can be downloaded
-            + expires: `2018-02-05T16:44:33+00:00` (string) - When the temporary download link expires
+            + location: `https://cdn.teamleader.eu/file` (string) - A temporary url where the requested file can be downloaded
+            + expires: `2018-02-05T16:44:33+00:00` (string) - Expiration time of the temporary download link

--- a/src/05-invoicing/credit-notes.apib
+++ b/src/05-invoicing/credit-notes.apib
@@ -133,3 +133,22 @@ Get details for a single credit note
                                     + value: `15.00` (number)
                 + created_at: `2016-02-04T16:44:33+00:00` (string)
                 + updated_at: `2016-02-05T16:44:33+00:00` (string)
+
+### creditNotes.download [POST /creditNotes.download]
+
+Download a credit note in a specific format.
+
++ Request (application/json;charset=utf-8)
+
+    + Attributes (object)
+        + id: `d885e5d5-bacb-4607-bde9-abc4a04a901b` (string, required)
+        + format: `pdf` (enum[string], required)
+            + Members
+                + pdf
+
++ Response 200 (application/json;charset=utf-8)
+
+    + Attributes (object)
+        + data (object)
+            + location: `https://cdn.teamleader.eu/file` (string) - A temporary url where the requested file can be downloaded from
+            + expires: `2018-02-05T16:44:33+00:00` (string) - When the temporary download link expires

--- a/src/05-invoicing/invoices.apib
+++ b/src/05-invoicing/invoices.apib
@@ -177,8 +177,8 @@ Download an invoice in a specific format.
 
     + Attributes (object)
         + data (object)
-            + location: `https://cdn.teamleader.eu/file` (string) - A temporary url from where the requested file can be downloaded
-            + expires: `2018-02-05T16:44:33+00:00` (string) - When the temporary download link expires
+            + location: `https://cdn.teamleader.eu/file` (string) - A temporary url where the requested file can be downloaded
+            + expires: `2018-02-05T16:44:33+00:00` (string) - Expiration time of the temporary download link
 
 ### invoices.draft [POST /invoices.draft]
 

--- a/src/05-invoicing/invoices.apib
+++ b/src/05-invoicing/invoices.apib
@@ -177,7 +177,7 @@ Download an invoice in a specific format.
 
     + Attributes (object)
         + data (object)
-            + location: `https://cdn.teamleader.eu/file` (string) - A temporary url where the requested file can be downloaded from
+            + location: `https://cdn.teamleader.eu/file` (string) - A temporary url from where the requested file can be downloaded
             + expires: `2018-02-05T16:44:33+00:00` (string) - When the temporary download link expires
 
 ### invoices.draft [POST /invoices.draft]


### PR DESCRIPTION
### Added
- `/creditNotes.download` documentation

### Changed
- Cleaned up language on invoices documentation