### PR TITLE
Marketing mails consent

### DIFF
--- a/apiary.apib
+++ b/apiary.apib
@@ -702,7 +702,7 @@ Get details for a single contact.
             + remarks: `First contact at expo` (string)
             + tags: prospect, expo (array[string])
             + custom_fields (array[CustomField])
-            + opted_in_for_mailings: false (boolean)
+            + marketing_mails_consent: false (boolean)
             + added_at: `2016-02-04T16:44:33+00:00` (string)
             + updated_at: `2016-02-05T16:44:33+00:00` (string)
 
@@ -744,6 +744,7 @@ Add a new contact.
         + bic: `BICBANK` (string, optional)
         + remarks: `Met at expo` (string, optional)
         + tags: prospect, expo (array[string], optional)
+        + marketing_mails_consent: false (boolean, optional)
 
 + Response 201 (application/json;charset=utf-8)
 
@@ -791,6 +792,7 @@ Update a contact.
         + bic: `BICBANK` (string, optional, nullable)
         + remarks: `Met at expo` (string, optional, nullable)
         + tags: prospect, expo (array[string], optional)
+        + marketing_mails_consent: false (boolean, optional)
 
 + Response 204
 
@@ -977,7 +979,7 @@ Get details for a single company.
             + updated_at: `2016-02-05T16:44:33+00:00` (string)
             + tags: prospect, expo (array[string])
             + custom_fields (array[CustomField])
-            + opted_in_for_mailings: false (boolean)
+            + marketing_mails_consent: false (boolean)
 
 ### companies.add [POST /companies.add]
 
@@ -1015,6 +1017,7 @@ Add a new company.
         + remarks: `Met at expo` (string, optional)
         + tags: prospect, expo (array[string], optional)
         + custom_fields (array[CustomFieldValue], optional)
+        + marketing_mails_consent: false (boolean, optional)
 
 + Response 201 (application/json;charset=utf-8)
 
@@ -1059,6 +1062,7 @@ Update a company.
         + responsible_user_id: `0ea94804-401d-4dbd-a577-c2d60998f798` (string, optional, nullable)
         + remarks: `Met at expo` (string, optional, nullable)
         + custom_fields (array[CustomFieldValue], optional)
+        + marketing_mails_consent: false (boolean, optional)
 
 + Response 204
 

--- a/src/02-crm/companies.apib
+++ b/src/02-crm/companies.apib
@@ -120,7 +120,7 @@ Get details for a single company.
             + updated_at: `2016-02-05T16:44:33+00:00` (string)
             + tags: prospect, expo (array[string])
             + custom_fields (array[CustomField])
-            + opted_in_for_mailings: false (boolean)
+            + marketing_mails_consent: false (boolean)
 
 ### companies.add [POST /companies.add]
 

--- a/src/02-crm/companies.apib
+++ b/src/02-crm/companies.apib
@@ -203,6 +203,7 @@ Update a company.
         + responsible_user_id: `0ea94804-401d-4dbd-a577-c2d60998f798` (string, optional, nullable)
         + remarks: `Met at expo` (string, optional, nullable)
         + custom_fields (array[CustomFieldValue], optional)
+        + marketing_mails_consent: false (boolean, optional)
 
 + Response 204
 

--- a/src/02-crm/companies.apib
+++ b/src/02-crm/companies.apib
@@ -158,6 +158,7 @@ Add a new company.
         + remarks: `Met at expo` (string, optional)
         + tags: prospect, expo (array[string], optional)
         + custom_fields (array[CustomFieldValue], optional)
+        + marketing_mails_consent: false (boolean, optional)
 
 + Response 201 (application/json;charset=utf-8)
 

--- a/src/02-crm/contacts.apib
+++ b/src/02-crm/contacts.apib
@@ -163,6 +163,7 @@ Add a new contact.
         + bic: `BICBANK` (string, optional)
         + remarks: `Met at expo` (string, optional)
         + tags: prospect, expo (array[string], optional)
+        + marketing_mails_consent: false (boolean, optional)
 
 + Response 201 (application/json;charset=utf-8)
 

--- a/src/02-crm/contacts.apib
+++ b/src/02-crm/contacts.apib
@@ -211,6 +211,7 @@ Update a contact.
         + bic: `BICBANK` (string, optional, nullable)
         + remarks: `Met at expo` (string, optional, nullable)
         + tags: prospect, expo (array[string], optional)
+        + marketing_mails_consent: false (boolean, optional)
 
 + Response 204
 

--- a/src/02-crm/contacts.apib
+++ b/src/02-crm/contacts.apib
@@ -121,7 +121,7 @@ Get details for a single contact.
             + remarks: `First contact at expo` (string)
             + tags: prospect, expo (array[string])
             + custom_fields (array[CustomField])
-            + opted_in_for_mailings: false (boolean)
+            + marketing_mails_consent: false (boolean)
             + added_at: `2016-02-04T16:44:33+00:00` (string)
             + updated_at: `2016-02-05T16:44:33+00:00` (string)
 


### PR DESCRIPTION
### Changed

- existing `opted_in_for_mailings` to `marketing_mails_consent` on `companies.info` and `contacts.info`

### Added

- `marketing_mails_consent` for `companies.{add,update}` and `contacts.{add,update}`

This PR closes #167 and #168 

---

Implementation: https://github.com/teamleadercrm/core/pull/5504
Tests: https://github.com/teamleadercrm/api-tests/pull/254