### PR TITLE
Add product category id to invoices update

### DIFF
--- a/apiary.apib
+++ b/apiary.apib
@@ -2045,6 +2045,7 @@ Update an invoice.
                             + type (enum[string], required)
                                 + Members
                                     + percentage
+                        + product_category_id: `e2314517-3cab-4aa9-8471-450e73449041` (string, optional)
         + invoice_date: `2016-02-04` (string, optional)
 
 + Response 204

--- a/src/05-invoicing/invoices.apib
+++ b/src/05-invoicing/invoices.apib
@@ -276,6 +276,7 @@ Update an invoice.
                             + type (enum[string], required)
                                 + Members
                                     + percentage
+                        + product_category_id: `e2314517-3cab-4aa9-8471-450e73449041` (string, optional)
         + invoice_date: `2016-02-04` (string, optional)
 
 + Response 204


### PR DESCRIPTION
### Added
- `/invoices.update` now accepts `product_category_id` on line items