### PR TITLE
Add documentation for extended_description fields on invoices

### DIFF
--- a/apiary.apib
+++ b/apiary.apib
@@ -1980,6 +1980,7 @@ Draft a new invoice.
                     + (object)
                         + quantity: `3` (number, required)
                         + description: `An awesome product` (string, required)
+                        + extended_description: `Some more information about this awesome product` (string) - Uses Markdown formatting
                         + unit_price (object)
                             + Include Money
                             + tax: `excluding` (enum[string], required)
@@ -2036,6 +2037,7 @@ Update an invoice.
                     + (object)
                         + quantity: `3` (number, required)
                         + description: `An awesome product` (string, required)
+                        + extended_description: `Some more information about this awesome product` (string) - Uses Markdown formatting
                         + unit_price (object)
                             + Include Money
                             + tax: `excluding` (enum[string])

--- a/src/05-invoicing/invoices.apib
+++ b/src/05-invoicing/invoices.apib
@@ -209,6 +209,7 @@ Draft a new invoice.
                     + (object)
                         + quantity: `3` (number, required)
                         + description: `An awesome product` (string, required)
+                        + extended_description: `Some more information about this awesome product` (string) - Uses Markdown formatting
                         + unit_price (object)
                             + Include Money
                             + tax: `excluding` (enum[string], required)
@@ -265,6 +266,7 @@ Update an invoice.
                     + (object)
                         + quantity: `3` (number, required)
                         + description: `An awesome product` (string, required)
+                        + extended_description: `Some more information about this awesome product` (string) - Uses Markdown formatting
                         + unit_price (object)
                             + Include Money
                             + tax: `excluding` (enum[string])


### PR DESCRIPTION
### Added
- `extended_description` on line item for `/invoices.draft`
- `extended_description` on line item for `/invoices.update`