### PR TITLE
Add correct filters for invoices and credit notes list

### DIFF
--- a/apiary.apib
+++ b/apiary.apib
@@ -1788,7 +1788,7 @@ Get a list of invoices.
                 + Members
                     + draft
                     + booked
-            + updated_since: `2016-02-04T16:44:33+00:00` (string)
+            + updated_since: `2016-02-04T16:44:33+00:00` (string, optional)
         + page (Page, optional)
         + sort (array, optional)
             + (object)
@@ -2122,6 +2122,9 @@ List credit notes
 + Request (application/json;charset=utf-8)
 
     + Attributes (object)
+        + filter (object, optional)
+            + department_id: `080aac72-ff1a-4627-bfe3-146b6eee979c` (string, optional) - The ID of the department you wish to filter on.
+            + updated_since: `2016-02-04T16:44:33+00:00` (string, optional)
         + page (Page, optional)
         + sort (array, optional)
             + (object)

--- a/apiary.apib
+++ b/apiary.apib
@@ -1788,6 +1788,7 @@ Get a list of invoices.
                 + Members
                     + draft
                     + booked
+            + updated_since: `2016-02-04T16:44:33+00:00` (string)
         + page (Page, optional)
         + sort (array, optional)
             + (object)

--- a/src/05-invoicing/credit-notes.apib
+++ b/src/05-invoicing/credit-notes.apib
@@ -11,6 +11,9 @@ List credit notes
 + Request (application/json;charset=utf-8)
 
     + Attributes (object)
+        + filter (object, optional)
+            + department_id: `080aac72-ff1a-4627-bfe3-146b6eee979c` (string, optional) - The ID of the department you wish to filter on.
+            + updated_since: `2016-02-04T16:44:33+00:00` (string, optional)
         + page (Page, optional)
         + sort (array, optional)
             + (object)

--- a/src/05-invoicing/invoices.apib
+++ b/src/05-invoicing/invoices.apib
@@ -17,7 +17,7 @@ Get a list of invoices.
                 + Members
                     + draft
                     + booked
-            + updated_since: `2016-02-04T16:44:33+00:00` (string)
+            + updated_since: `2016-02-04T16:44:33+00:00` (string, optional)
         + page (Page, optional)
         + sort (array, optional)
             + (object)

--- a/src/05-invoicing/invoices.apib
+++ b/src/05-invoicing/invoices.apib
@@ -17,6 +17,7 @@ Get a list of invoices.
                 + Members
                     + draft
                     + booked
+            + updated_since: `2016-02-04T16:44:33+00:00` (string)
         + page (Page, optional)
         + sort (array, optional)
             + (object)


### PR DESCRIPTION
### Added
- `updated_since` filter on `/invoices.list`
- `updated_since` filter on `/creditNotes.list`
- `department_id` filter on `/creditNotes.list`