### PR TITLE
Timetracking.add variant with ended_at

### DIFF
--- a/apiary.apib
+++ b/apiary.apib
@@ -2789,6 +2789,9 @@ Add tracked time.
             + Properties
                 + started_at: `2017-04-26T10:01:49+00:00` (string, required)
                 + duration: 3600 (number, required) - In seconds
+            + Properties
+                + started_at: `2017-04-26T10:01:49+00:00` (string, required)
+                + ended_at: `2017-04-26T16:02:00+00:00` (string, required)
         + description (string, optional)
         + subject (object, optional)
             + type: `milestone` (enum[string], required)

--- a/src/06-time-tracking/time-tracking.apib
+++ b/src/06-time-tracking/time-tracking.apib
@@ -103,6 +103,9 @@ Add tracked time.
             + Properties
                 + started_at: `2017-04-26T10:01:49+00:00` (string, required)
                 + duration: 3600 (number, required) - In seconds
+            + Properties
+                + started_at: `2017-04-26T10:01:49+00:00` (string, required)
+                + ended_at: `2017-04-26T16:02:00+00:00` (string, required)
         + description (string, optional)
         + subject (object, optional)
             + type: `milestone` (enum[string], required)


### PR DESCRIPTION
Enable the `started_at` + `ended_at` option when adding a time tracking.