### PR TITLE
Add `ended_at` filter

### DIFF
--- a/apiary.apib
+++ b/apiary.apib
@@ -2705,6 +2705,7 @@ Get a list of tracked time.
             + user_id: `87982c96-f2fe-4b05-838c-ff42c0525758` (string, optional)
             + started_after: `2017-04-26T10:01:49+00:00` (string, optional)
             + started_before: `2017-04-26T10:01:49+00:00` (string, optional)
+            + ended_after: `2017-04-26T10:01:49+00:00` (string, optional)
         + page (Page, optional)
         + sort (array, optional)
             + (object)

--- a/src/06-time-tracking/time-tracking.apib
+++ b/src/06-time-tracking/time-tracking.apib
@@ -13,6 +13,7 @@ Get a list of tracked time.
             + user_id: `87982c96-f2fe-4b05-838c-ff42c0525758` (string, optional)
             + started_after: `2017-04-26T10:01:49+00:00` (string, optional)
             + started_before: `2017-04-26T10:01:49+00:00` (string, optional)
+            + ended_after: `2017-04-26T10:01:49+00:00` (string, optional)
         + page (Page, optional)
         + sort (array, optional)
             + (object)


### PR DESCRIPTION
Adds a new filter for `timetrackings.list` to filter by `ended_after` 