### PR TITLE
Add a little note about splitting up time trackings

### DIFF
--- a/apiary.apib
+++ b/apiary.apib
@@ -2789,6 +2789,8 @@ Add tracked time.
 
 + Request (application/json)
 
+    Note that the time tracking entry will be split up if the time span passes midnight.
+
     + Attributes (object)
         + work_type_id: `2175597d-484e-4a1c-a781-cbc3d9f893ba` (string, optional)
         + One Of

--- a/src/06-time-tracking/time-tracking.apib
+++ b/src/06-time-tracking/time-tracking.apib
@@ -97,6 +97,8 @@ Add tracked time.
 
 + Request (application/json)
 
+    Note that the time tracking entry will be split up if the time span passes midnight.
+
     + Attributes (object)
         + work_type_id: `2175597d-484e-4a1c-a781-cbc3d9f893ba` (string, optional)
         + One Of


### PR DESCRIPTION
Added a small notice to make clear that we split up time-trackings that pass midnight in their timespan