### PR TITLE
Add hourly rate type to projects create

### DIFF
--- a/apiary.apib
+++ b/apiary.apib
@@ -2474,21 +2474,21 @@ Create a new project.
         + title: `New company website` (string, required)
         + description (string, optional)
         + starts_on: `2016-02-04` (string, required)
-        + billing_method (object, required)
+        + billing_method (object, optional)
             + One Of
                 + Properties
                     + method: `fixed` (string, required)
                     + amount (Money, required)
                 + Properties
-                    + method: `hourly_rate` (string, required)
-                    + hourly_rate (object, required)
+                    + method: `time_material` (string, required)
+                    + rate (object, required)
                         + One Of
                             + Properties
-                                + based_on: `user` (string, required)
+                                + `based_on`: `jezus_christus` (string, required)
                             + Properties
-                                + based_on: `work_type` (string, required)
+                                + `based_on`: `user` (string, required)
                             + Properties
-                                + based_on: `custom` (string, required)
+                                + `based_on`: `custom` (string, required)
                                 + rate (Money, required)
         + milestones (array, required) - At least one milestone is required
             + (object)

--- a/apiary.apib
+++ b/apiary.apib
@@ -2480,6 +2480,7 @@ Create a new project.
                     + method: `fixed` (string, required)
                     + amount (Money, required)
                 + Properties
+                    + method: `hourly_rate` (string, required)
                     + hourly_rate (object, required)
                         + One Of
                             + Properties

--- a/apiary.apib
+++ b/apiary.apib
@@ -2484,12 +2484,12 @@ Create a new project.
                     + rate (object, required)
                         + One Of
                             + Properties
-                                + `based_on`: `jezus_christus` (string, required)
-                            + Properties
                                 + `based_on`: `user` (string, required)
                             + Properties
+                                + `based_on`: `work_type` (string, required)
+                            + Properties
                                 + `based_on`: `custom` (string, required)
-                                + rate (Money, required)
+                                + amount (Money, required)
         + milestones (array, required) - At least one milestone is required
             + (object)
                 + due_on: `2018-01-01` (string, required)

--- a/apiary.apib
+++ b/apiary.apib
@@ -2474,15 +2474,21 @@ Create a new project.
         + title: `New company website` (string, required)
         + description (string, optional)
         + starts_on: `2016-02-04` (string, required)
-        + hourly_rate (object, required)
+        + billing_method (object, required)
             + One Of
                 + Properties
-                    + type: `user` (string, required)
+                    + method: `fixed` (string, required)
+                    + amount (Money, required)
                 + Properties
-                    + type: `task` (string, required)
-                + Properties
-                    + type: `fixed` (string, required)
-                    + rate: `123` (number, required)
+                    + hourly_rate (object, required)
+                        + One Of
+                            + Properties
+                                + based_on: `user` (string, required)
+                            + Properties
+                                + based_on: `work_type` (string, required)
+                            + Properties
+                                + based_on: `custom` (string, required)
+                                + rate (Money, required)
         + milestones (array, required) - At least one milestone is required
             + (object)
                 + due_on: `2018-01-01` (string, required)

--- a/apiary.apib
+++ b/apiary.apib
@@ -2474,6 +2474,15 @@ Create a new project.
         + title: `New company website` (string, required)
         + description (string, optional)
         + starts_on: `2016-02-04` (string, required)
+        + hourly_rate (object, required)
+            + One Of
+                + Properties
+                    + type: `user` (string, required)
+                + Properties
+                    + type: `task` (string, required)
+                + Properties
+                    + type: `fixed` (string, required)
+                    + rate: `123` (number, required)
         + milestones (array, required) - At least one milestone is required
             + (object)
                 + due_on: `2018-01-01` (string, required)

--- a/src/07-projects/projects.apib
+++ b/src/07-projects/projects.apib
@@ -114,11 +114,11 @@ Create a new project.
         + hourly_rate (object, required)
             + One Of
                 + Properties
-                    + type: `user` (string, required)
+                    + based_on: `user` (string, required)
                 + Properties
-                    + type: `work_type` (string, required)
+                    + based_on: `work_type` (string, required)
                 + Properties
-                    + type: `fixed` (string, required)
+                    + based_on: `fixed` (string, required)
                     + rate (Money, required)
         + milestones (array, required) - At least one milestone is required
             + (object)

--- a/src/07-projects/projects.apib
+++ b/src/07-projects/projects.apib
@@ -112,7 +112,7 @@ Create a new project.
         + description (string, optional)
         + starts_on: `2016-02-04` (string, required)
         + billing_method (object, required)
-            + One of
+            + One Of
                 + Properties
                     + method: `fixed` (string, required)
                     + amount (Money, required)

--- a/src/07-projects/projects.apib
+++ b/src/07-projects/projects.apib
@@ -112,15 +112,14 @@ Create a new project.
         + description (string, optional)
         + starts_on: `2016-02-04` (string, required)
         + hourly_rate (object, required)
-            + (object)
-                + One Of
-                    + Properties
-                        + type: `user` (string, required)
-                    + Properties
-                        + type: `task` (string, required)
-                    + Properties
-                        + type: `fixed` (string, required)
-                        + rate: `123` (integer, required)
+            + One Of
+                + Properties
+                    + type: `user` (string, required)
+                + Properties
+                    + type: `task` (string, required)
+                + Properties
+                    + type: `fixed` (string, required)
+                    + rate: `123` (number, required)
         + milestones (array, required) - At least one milestone is required
             + (object)
                 + due_on: `2018-01-01` (string, required)

--- a/src/07-projects/projects.apib
+++ b/src/07-projects/projects.apib
@@ -111,7 +111,7 @@ Create a new project.
         + title: `New company website` (string, required)
         + description (string, optional)
         + starts_on: `2016-02-04` (string, required)
-        + billing_method (object, required)
+        + billing_method (object, optional)
             + One Of
                 + Properties
                     + method: `fixed` (string, required)

--- a/src/07-projects/projects.apib
+++ b/src/07-projects/projects.apib
@@ -117,6 +117,7 @@ Create a new project.
                     + method: `fixed` (string, required)
                     + amount (Money, required)
                 + Properties
+                    + method: `hourly_rate` (string, required)
                     + hourly_rate (object, required)
                         + One Of
                             + Properties

--- a/src/07-projects/projects.apib
+++ b/src/07-projects/projects.apib
@@ -116,7 +116,7 @@ Create a new project.
                 + Properties
                     + type: `user` (string, required)
                 + Properties
-                    + type: `task` (string, required)
+                    + type: `work_type` (string, required)
                 + Properties
                     + type: `fixed` (string, required)
                     + rate: `123` (number, required)

--- a/src/07-projects/projects.apib
+++ b/src/07-projects/projects.apib
@@ -118,14 +118,14 @@ Create a new project.
                     + amount (Money, required)
                 + Properties
                     + method: `time_material` (string, required)
-                    + hourly_rate (object, required)
+                    + rate (object, required)
                         + One Of
                             + Properties
-                                + based_on: `user` (string, required)
+                                + `based_on`: `user` (string, required)
                             + Properties
-                                + based_on: `work_type` (string, required)
+                                + `based_on`: `work_type` (string, required)
                             + Properties
-                                + based_on: `custom` (string, required)
+                                + `based_on`: `custom` (string, required)
                                 + rate (Money, required)
         + milestones (array, required) - At least one milestone is required
             + (object)

--- a/src/07-projects/projects.apib
+++ b/src/07-projects/projects.apib
@@ -117,7 +117,7 @@ Create a new project.
                     + method: `fixed` (string, required)
                     + amount (Money, required)
                 + Properties
-                    + method: `hourly_rate` (string, required)
+                    + method: `time_material` (string, required)
                     + hourly_rate (object, required)
                         + One Of
                             + Properties

--- a/src/07-projects/projects.apib
+++ b/src/07-projects/projects.apib
@@ -111,15 +111,21 @@ Create a new project.
         + title: `New company website` (string, required)
         + description (string, optional)
         + starts_on: `2016-02-04` (string, required)
-        + hourly_rate (object, required)
-            + One Of
+        + billing_method (object, required)
+            + One of
                 + Properties
-                    + based_on: `user` (string, required)
+                    + method: `fixed` (string, required)
+                    + amount (Money, required)
                 + Properties
-                    + based_on: `work_type` (string, required)
-                + Properties
-                    + based_on: `fixed` (string, required)
-                    + rate (Money, required)
+                    + hourly_rate (object, required)
+                        + One Of
+                            + Properties
+                                + based_on: `user` (string, required)
+                            + Properties
+                                + based_on: `work_type` (string, required)
+                            + Properties
+                                + based_on: `custom` (string, required)
+                                + rate (Money, required)
         + milestones (array, required) - At least one milestone is required
             + (object)
                 + due_on: `2018-01-01` (string, required)

--- a/src/07-projects/projects.apib
+++ b/src/07-projects/projects.apib
@@ -111,6 +111,16 @@ Create a new project.
         + title: `New company website` (string, required)
         + description (string, optional)
         + starts_on: `2016-02-04` (string, required)
+        + hourly_rate (object, required)
+            + (object)
+                + One Of
+                    + Properties
+                        + type: `user` (string, required)
+                    + Properties
+                        + type: `task` (string, required)
+                    + Properties
+                        + type: `fixed` (string, required)
+                        + rate: `123` (integer, required)
         + milestones (array, required) - At least one milestone is required
             + (object)
                 + due_on: `2018-01-01` (string, required)

--- a/src/07-projects/projects.apib
+++ b/src/07-projects/projects.apib
@@ -126,7 +126,7 @@ Create a new project.
                                 + `based_on`: `work_type` (string, required)
                             + Properties
                                 + `based_on`: `custom` (string, required)
-                                + rate (Money, required)
+                                + amount (Money, required)
         + milestones (array, required) - At least one milestone is required
             + (object)
                 + due_on: `2018-01-01` (string, required)

--- a/src/07-projects/projects.apib
+++ b/src/07-projects/projects.apib
@@ -119,7 +119,7 @@ Create a new project.
                     + type: `work_type` (string, required)
                 + Properties
                     + type: `fixed` (string, required)
-                    + rate: `123` (number, required)
+                    + rate (Money, required)
         + milestones (array, required) - At least one milestone is required
             + (object)
                 + due_on: `2018-01-01` (string, required)


### PR DESCRIPTION
### Important information about this pull request

Before we start implementing the actual functionality, we want some opinions and insights. The best way, we figured, was to show what we need through the API docs. I will not merge this PR, this is just to gather comments.

### What are we trying/going to do?

In order to further streamline the add project flow, the `projects.create` endpoint must be extended with the type of hourly rate. There are three distinct possibilities:

- hourly rate type "user": every user added to the project will use the default rate for that user from the settings.
- hourly rate type "task": every task in this project will use the default rate for that task from the settings.
- hourly rate type "fixed": each user, for each task, will use this hourly rate. In this case, the actual rate must also be supplied.

It will be possible to override rates for tasks and users, but only when editing the project.