### PR TITLE
All address fields are required

### DIFF
--- a/apiary.apib
+++ b/apiary.apib
@@ -3028,9 +3028,9 @@ Translates "meeting", "call" and "task" into their respective activity type UUID
 + number: `092980615` (string, required)
 
 ## Address (object)
-+ line_1: `Dok Noord 3A 101` (string, optional)
-+ postal_code: `9000` (string, optional)
-+ city: `Ghent` (string, optional)
++ line_1: `Dok Noord 3A 101` (string, required, nullable)
++ postal_code: `9000` (string, required, nullable)
++ city: `Ghent` (string, required, nullable)
 + country: `BE` (string, required)
 
 ## Addressee (object)

--- a/src/datastructures.apib
+++ b/src/datastructures.apib
@@ -16,9 +16,9 @@
 + number: `092980615` (string, required)
 
 ## Address (object)
-+ line_1: `Dok Noord 3A 101` (string, optional)
-+ postal_code: `9000` (string, optional)
-+ city: `Ghent` (string, optional)
++ line_1: `Dok Noord 3A 101` (string, required, nullable)
++ postal_code: `9000` (string, required, nullable)
++ city: `Ghent` (string, required, nullable)
 + country: `BE` (string, required)
 
 ## Addressee (object)


### PR DESCRIPTION
Our API expects all address field to be sent on API calls, but our API doesn't reflect this. Either we loosen our input validation, or apply this documentation change 👌 