### PR TITLE
Update missing documentation for timeTracking.delete

### DIFF
--- a/apiary.apib
+++ b/apiary.apib
@@ -2910,7 +2910,7 @@ Start a new timer based on previously tracked time.
             + type: `timer` (string)
             + id: `f01adf4a-bb9b-45de-b231-615cd0e941de` (string)
 
-### timeTracking.delete [GET /timeTracking.delete]
+### timeTracking.delete [POST /timeTracking.delete]
 
 Delete a tracked time.
 

--- a/apiary.apib
+++ b/apiary.apib
@@ -2910,6 +2910,17 @@ Start a new timer based on previously tracked time.
             + type: `timer` (string)
             + id: `f01adf4a-bb9b-45de-b231-615cd0e941de` (string)
 
+### timeTracking.delete [GET /timeTracking.delete]
+
+Delete a tracked time.
+
++ Request (application/json)
+
+    + Attributes (object)
+        + id: `6caeea11-aa83-4da9-9859-5b62bbf3a476` (string, required)
+
++ Response 204
+
 ## Timers [/timers]
 
 Timers are an easy way to track time. You can start, stop or resume a timer any time. However, only one timer can run simultaneously per user. Every action will result in the creation or update of a time tracking.

--- a/src/06-time-tracking/time-tracking.apib
+++ b/src/06-time-tracking/time-tracking.apib
@@ -173,7 +173,7 @@ Start a new timer based on previously tracked time.
             + type: `timer` (string)
             + id: `f01adf4a-bb9b-45de-b231-615cd0e941de` (string)
 
-### timeTracking.delete [GET /timeTracking.delete]
+### timeTracking.delete [POST /timeTracking.delete]
 
 Delete a tracked time.
 

--- a/src/06-time-tracking/time-tracking.apib
+++ b/src/06-time-tracking/time-tracking.apib
@@ -172,3 +172,14 @@ Start a new timer based on previously tracked time.
         + data (object)
             + type: `timer` (string)
             + id: `f01adf4a-bb9b-45de-b231-615cd0e941de` (string)
+
+### timeTracking.delete [GET /timeTracking.delete]
+
+Delete a tracked time.
+
++ Request (application/json)
+
+    + Attributes (object)
+        + id: `6caeea11-aa83-4da9-9859-5b62bbf3a476` (string, required)
+
++ Response 204


### PR DESCRIPTION
The implementation for timeTracking.delete was already in use but not documented.

Implementation: https://github.com/teamleadercrm/service-time-tracking/pull/72