### PR TITLE
Fix `tax_rate_id` field name in invoices.update endpoint

### DIFF
--- a/src/05-invoicing/invoices.apib
+++ b/src/05-invoicing/invoices.apib
@@ -283,7 +283,7 @@ Update an invoice.
                             + tax: `excluding` (enum[string])
                                 + Members
                                     + excluding
-                        + tax_id: `c0c03f1e-77e3-402c-a713-30ea1c585823` (string, required)
+                        + tax_rate_id: `c0c03f1e-77e3-402c-a713-30ea1c585823` (string, required)
                         + discount (object, required)
                             + value: 10 (number, required) - Values between 0 and 100
                             + type (enum[string], required)


### PR DESCRIPTION
### Fixed
- `/invoices.update` endpoint had incorrect field name for updating an item's `tax_rate_id`

---
*Note:* The implementation always had the correct name, it was incorrectly documented