### PR TITLE
Rename remarks to note

### DIFF
--- a/apiary.apib
+++ b/apiary.apib
@@ -1975,7 +1975,7 @@ Get details for a single invoice.
                     + payment (object)
                         + Include Money
             + payment_reference: `+++084/2613/66074+++` (string)
-            + remarks: `'Some extra remarks about the invoice'` (string)
+            + note: `'Some extra remarks about the invoice'` (string)
             + created_at: `2016-02-04T16:44:33+00:00` (string)
             + updated_at: `2016-02-05T16:44:33+00:00` (string)
 
@@ -2047,7 +2047,7 @@ Draft a new invoice.
                     + Members
                         + percentage
                 + description: `winter promotion` (string, required)
-        + remarks: `Invoice comments` (string, optional)
+        + note: `Invoice comments` (string, optional)
 
 + Response 201 (application/json;charset=utf-8)
 

--- a/src/05-invoicing/invoices.apib
+++ b/src/05-invoicing/invoices.apib
@@ -170,7 +170,7 @@ Get details for a single invoice.
                     + payment (object)
                         + Include Money
             + payment_reference: `+++084/2613/66074+++` (string)
-            + remarks: `'Some extra remarks about the invoice'` (string)
+            + note: `'Some extra remarks about the invoice'` (string)
             + created_at: `2016-02-04T16:44:33+00:00` (string)
             + updated_at: `2016-02-05T16:44:33+00:00` (string)
 
@@ -242,7 +242,7 @@ Draft a new invoice.
                     + Members
                         + percentage
                 + description: `winter promotion` (string, required)
-        + remarks: `Invoice comments` (string, optional)
+        + note: `Invoice comments` (string, optional)
 
 + Response 201 (application/json;charset=utf-8)
 


### PR DESCRIPTION
### Changed
- Renamed `remarks` field to `note` on `/invoices.draft` and `/invoices.info`