### PR TITLE
User preferences

### DIFF
--- a/apiary.apib
+++ b/apiary.apib
@@ -332,24 +332,32 @@ Get the current authenticated user.
             + last_name: `Smith` (string)
             + email: `john@teamleader.eu` (string)
             + telephones (array[Telephone])
-            + language: `nl-BE` (enum[string])
-                + Members
-                    + da-DK
-                    + de-DE
-                    + en-GB
-                    + es-ES
-                    + fi-FI
-                    + fr-FR
-                    + it-IT
-                    + nb-NO
-                    + nl-BE
-                    + nl-NL
-                    + pl-PL
-                    + pt-PT
-                    + sv-SE
-                    + tr-TR
             + function: `Sales` (string)
-            + time_zone: `Europe/Brussels` (string)
+            + preferences (object)
+                + language: `nl-BE` (enum[string])
+                    + Members
+                        + da-DK
+                        + de-DE
+                        + en-GB
+                        + es-ES
+                        + fi-FI
+                        + fr-FR
+                        + it-IT
+                        + nb-NO
+                        + nl-BE
+                        + nl-NL
+                        + pl-PL
+                        + pt-PT
+                        + sv-SE
+                        + tr-TR
+                + time_zone: `Europe/Brussels` (string)
+                + date_format (object)
+                    + short: `dd/mm/yyyy` (string)
+                    + medium: `dd mmm yyyy` (string)
+                    + long: `dd mmmm yyyy` (string)
+                + number_format (object)
+                    + thousand_separator: ' ' (string)
+                    + decimal_separator: '.' (string)
 
 ### users.list [GET /users.list]
 

--- a/apiary.apib
+++ b/apiary.apib
@@ -356,7 +356,7 @@ Get the current authenticated user.
                     + medium: `dd mmm yyyy` (string)
                     + long: `dd mmmm yyyy` (string)
                 + number_format (object)
-                    + thousand_separator: ' ' (string)
+                    + thousands_separator: ' ' (string)
                     + decimal_separator: '.' (string)
 
 ### users.list [GET /users.list]

--- a/src/01-general/users.apib
+++ b/src/01-general/users.apib
@@ -44,7 +44,7 @@ Get the current authenticated user.
                     + medium: `dd mmm yyyy` (string)
                     + long: `dd mmmm yyyy` (string)
                 + number_format (object)
-                    + thousand_separator: ' ' (string)
+                    + thousands_separator: ' ' (string)
                     + decimal_separator: '.' (string)
 
 ### users.list [GET /users.list]

--- a/src/01-general/users.apib
+++ b/src/01-general/users.apib
@@ -20,24 +20,32 @@ Get the current authenticated user.
             + last_name: `Smith` (string)
             + email: `john@teamleader.eu` (string)
             + telephones (array[Telephone])
-            + language: `nl-BE` (enum[string])
-                + Members
-                    + da-DK
-                    + de-DE
-                    + en-GB
-                    + es-ES
-                    + fi-FI
-                    + fr-FR
-                    + it-IT
-                    + nb-NO
-                    + nl-BE
-                    + nl-NL
-                    + pl-PL
-                    + pt-PT
-                    + sv-SE
-                    + tr-TR
             + function: `Sales` (string)
-            + time_zone: `Europe/Brussels` (string)
+            + preferences (object)
+                + language: `nl-BE` (enum[string])
+                    + Members
+                        + da-DK
+                        + de-DE
+                        + en-GB
+                        + es-ES
+                        + fi-FI
+                        + fr-FR
+                        + it-IT
+                        + nb-NO
+                        + nl-BE
+                        + nl-NL
+                        + pl-PL
+                        + pt-PT
+                        + sv-SE
+                        + tr-TR
+                + time_zone: `Europe/Brussels` (string)
+                + date_format (object)
+                    + short: `dd/mm/yyyy` (string)
+                    + medium: `dd mmm yyyy` (string)
+                    + long: `dd mmmm yyyy` (string)
+                + number_format (object)
+                    + thousand_separator: ' ' (string)
+                    + decimal_separator: '.' (string)
 
 ### users.list [GET /users.list]
 


### PR DESCRIPTION
It would be handy for our frontend services and third party integrations, to know what kind of date formatting and number formatting preferences a user has. Currently, this is not adjustable through your user settings, but it could be in the future. For now this will be a read-only property that is generated by the backend, based on the user language and account country.

While adding the `preferences` root property to the user object, I realised that the time zone and language could also be considered a preference. Eg. everything that has an impact on how things are displayed in Teamleader.

**This would be a breaking change**. Unless we can find a better name for the property/structure, I think we should not be afraid to make breaking changes.

---

The date format was based on this Wikipedia article: https://en.wikipedia.org/wiki/Date_format_by_country

```
yy – two-digit year, e.g. 96
yyyy – four-digit year, e.g. 1996
m – one-digit month for months below 10, e.g. 4
mm – two-digit month, e.g. 04
mmm – three-letter abbreviation for month, e.g. Apr
mmmm – month spelled out in full, e.g. April
d – one-digit day of the month for days below 10, e.g. 2
dd – two-digit day of the month, e.g. 02
ddd – three-letter abbreviation for day of the week, e.g. Tue
dddd – day of the week spelled out in full, e.g. Tuesday
```