### PR TITLE
Line item discounts are now optional when updating an invoice

### DIFF
--- a/apiary.apib
+++ b/apiary.apib
@@ -2098,7 +2098,7 @@ Update an invoice.
                                 + Members
                                     + excluding
                         + tax_rate_id: `c0c03f1e-77e3-402c-a713-30ea1c585823` (string, required)
-                        + discount (object, required)
+                        + discount (object, optional)
                             + value: 10 (number, required) - Values between 0 and 100
                             + type (enum[string], required)
                                 + Members

--- a/src/05-invoicing/invoices.apib
+++ b/src/05-invoicing/invoices.apib
@@ -286,7 +286,7 @@ Update an invoice.
                                 + Members
                                     + excluding
                         + tax_rate_id: `c0c03f1e-77e3-402c-a713-30ea1c585823` (string, required)
-                        + discount (object, required)
+                        + discount (object, optional)
                             + value: 10 (number, required) - Values between 0 and 100
                             + type (enum[string], required)
                                 + Members


### PR DESCRIPTION
When updating an invoice line item it was always required to send the discount even when the line item didn't have a discount. This PR makes the discount line item optional.