### PR TITLE
Add missing colon for example value

### DIFF
--- a/apiary.apib
+++ b/apiary.apib
@@ -634,7 +634,7 @@ Get a list of all work types, sorted alphabetically (on their name).
         + data (array)
             + (object)
                 + id: `811a5825-96f4-4318-83c3-2840935c6003` (string)
-                + name `Planning` (string)
+                + name: `Planning` (string)
 
 # Group CRM
 

--- a/src/01-general/work-types.apib
+++ b/src/01-general/work-types.apib
@@ -24,4 +24,4 @@ Get a list of all work types, sorted alphabetically (on their name).
         + data (array)
             + (object)
                 + id: `811a5825-96f4-4318-83c3-2840935c6003` (string)
-                + name `Planning` (string)
+                + name: `Planning` (string)


### PR DESCRIPTION
There was a missing colon in the reponse for the `worktypes.list` endpoint, which broke the example in the visual representation.