### PR TITLE
Add Electronic Invoicing Address to the invoicee on the Invoices.info

### DIFF
--- a/apiary.apib
+++ b/apiary.apib
@@ -2000,6 +2000,7 @@ Get details for a single invoice.
                         + id: `f88ab83c-b8ca-497b-a2c6-1ad631fe1cea` (string)
                 + email: `duivels@test.com` (string, nullable)
                 + local_business_number: `123` (string, nullable)
+                + digital_invoicing_address: `YQ1234` (string, nullable)
             + discounts (array)
                 + (object)
                     + type: `percentage` (enum[string])

--- a/apiary.apib
+++ b/apiary.apib
@@ -2000,7 +2000,7 @@ Get details for a single invoice.
                         + id: `f88ab83c-b8ca-497b-a2c6-1ad631fe1cea` (string)
                 + email: `duivels@test.com` (string, nullable)
                 + local_business_number: `123` (string, nullable)
-                + digital_invoicing_address: `YQ1234` (string, nullable)
+                + electronic_invoicing_address: `YQ1234` (string, nullable)
             + discounts (array)
                 + (object)
                     + type: `percentage` (enum[string])

--- a/src/05-invoicing/invoices.apib
+++ b/src/05-invoicing/invoices.apib
@@ -112,6 +112,7 @@ Get details for a single invoice.
                         + id: `f88ab83c-b8ca-497b-a2c6-1ad631fe1cea` (string)
                 + email: `duivels@test.com` (string, nullable)
                 + local_business_number: `123` (string, nullable)
+                + digital_invoicing_address: `YQ1234` (string, nullable)
             + discounts (array)
                 + (object)
                     + type: `percentage` (enum[string])

--- a/src/05-invoicing/invoices.apib
+++ b/src/05-invoicing/invoices.apib
@@ -112,7 +112,7 @@ Get details for a single invoice.
                         + id: `f88ab83c-b8ca-497b-a2c6-1ad631fe1cea` (string)
                 + email: `duivels@test.com` (string, nullable)
                 + local_business_number: `123` (string, nullable)
-                + digital_invoicing_address: `YQ1234` (string, nullable)
+                + electronic_invoicing_address: `YQ1234` (string, nullable)
             + discounts (array)
                 + (object)
                     + type: `percentage` (enum[string])


### PR DESCRIPTION
The Electronic Invoicing Address is part of the e-invoice for Italy that corresponds to the `Codice Destinario` required property.