### PR TITLE
Add withholding_tax_rate_id to invoices draft and update

### DIFF
--- a/apiary.apib
+++ b/apiary.apib
@@ -2116,6 +2116,7 @@ Draft a new invoice.
                                 + Members
                                     + excluding
                         + tax_rate_id: `c0c03f1e-77e3-402c-a713-30ea1c585823` (string, required)
+                        + withholding_tax_rate_id: `c0c03f1e-77e3-402c-a713-30ea1c585824` (string, optional)
                         + discount (object, optional)
                             + value: 10 (number, required) - Values between 0 and 100
                             + type (enum[string], required)
@@ -2174,6 +2175,7 @@ Update an invoice.
                                 + Members
                                     + excluding
                         + tax_rate_id: `c0c03f1e-77e3-402c-a713-30ea1c585823` (string, required)
+                        + withholding_tax_rate_id: `c0c03f1e-77e3-402c-a713-30ea1c585824` (string, optional)
                         + discount (object, optional)
                             + value: 10 (number, required) - Values between 0 and 100
                             + type (enum[string], required)

--- a/src/05-invoicing/invoices.apib
+++ b/src/05-invoicing/invoices.apib
@@ -228,6 +228,7 @@ Draft a new invoice.
                                 + Members
                                     + excluding
                         + tax_rate_id: `c0c03f1e-77e3-402c-a713-30ea1c585823` (string, required)
+                        + withholding_tax_rate_id: `c0c03f1e-77e3-402c-a713-30ea1c585824` (string, optional)
                         + discount (object, optional)
                             + value: 10 (number, required) - Values between 0 and 100
                             + type (enum[string], required)
@@ -286,6 +287,7 @@ Update an invoice.
                                 + Members
                                     + excluding
                         + tax_rate_id: `c0c03f1e-77e3-402c-a713-30ea1c585823` (string, required)
+                        + withholding_tax_rate_id: `c0c03f1e-77e3-402c-a713-30ea1c585824` (string, optional)
                         + discount (object, optional)
                             + value: 10 (number, required) - Values between 0 and 100
                             + type (enum[string], required)


### PR DESCRIPTION
In Italy they have a different tax system, the withholding taxes. For the e-invoicing changes, we also need to add information about the withholding taxes to invoices so that it can be used to generate a document to be sent to the Italian government.