### PR TITLE
Add bookyear to invoice numbers

### DIFF
--- a/apiary.apib
+++ b/apiary.apib
@@ -298,6 +298,12 @@ _This will only affect the version for those API calls and won't affect any othe
 
 We list all backwards-incompatible changes here. As described above, new additions and forwards-compatible changes don’t need a new API version and will not appear in this list.
 
+#### Beta
+
+- Added the bookyear name to the `invoice_number` on `invoices.list` and `invoices.info`.
+  Earlier it was only returning the number, e.g. `"27"`.
+  Now it adds the name of the bookyear as well, e.g. `"2018 / 27`".
+
 #### 2018-10-30
 
 - The top-level property `customer` was removed on all deal endpoints.
@@ -1929,7 +1935,7 @@ Get a list of invoices.
                 + department (object)
                     + type: `department` (string)
                     + id: `5e90eb0a-b502-4344-aa0f-3b8525af6186` (string)
-                + invoice_number: `2017/5` (string, nullable)
+                + invoice_number: `2017 / 5` (string, nullable)
                 + invoice_date: `2016-02-04` (string, nullable)
                 + status: `booked` (enum[string])
                     + Members
@@ -1978,7 +1984,7 @@ Get details for a single invoice.
             + department (object)
                 + type: `department` (string)
                 + id: `8f802cba-443b-4c69-800f-5852e967000b` (string)
-            + invoice_number: `2017/5` (string, nullable)
+            + invoice_number: `2017 / 5` (string, nullable)
             + invoice_date: `2016-02-04` (string, nullable)
             + status: `booked` (enum[string])
                 + Members

--- a/src/05-invoicing/invoices.apib
+++ b/src/05-invoicing/invoices.apib
@@ -41,7 +41,7 @@ Get a list of invoices.
                 + department (object)
                     + type: `department` (string)
                     + id: `5e90eb0a-b502-4344-aa0f-3b8525af6186` (string)
-                + invoice_number: `2017/5` (string, nullable)
+                + invoice_number: `2017 / 5` (string, nullable)
                 + invoice_date: `2016-02-04` (string, nullable)
                 + status: `booked` (enum[string])
                     + Members
@@ -90,7 +90,7 @@ Get details for a single invoice.
             + department (object)
                 + type: `department` (string)
                 + id: `8f802cba-443b-4c69-800f-5852e967000b` (string)
-            + invoice_number: `2017/5` (string, nullable)
+            + invoice_number: `2017 / 5` (string, nullable)
             + invoice_date: `2016-02-04` (string, nullable)
             + status: `booked` (enum[string])
                 + Members

--- a/src/changes.apib
+++ b/src/changes.apib
@@ -48,6 +48,12 @@ _This will only affect the version for those API calls and won't affect any othe
 
 We list all backwards-incompatible changes here. As described above, new additions and forwards-compatible changes don’t need a new API version and will not appear in this list.
 
+#### Beta
+
+- Added the bookyear name to the `invoice_number` on `invoices.list` and `invoices.info`.
+  Earlier it was only returning the number, e.g. `"27"`.
+  Now it adds the name of the bookyear as well, e.g. `"2018 / 27`".
+
 #### 2018-10-30
 
 - The top-level property `customer` was removed on all deal endpoints.


### PR DESCRIPTION
- documented the breaking change where we added the bookyear name to the invoice number.
- corrected the formatting in the example invoice numbers

We currently are not adding the bookyear to the invoice number, so this is in fact a bug. But treating it as a breaking change, as people might have implemented things with wrong invoice numbers.