### PR TITLE
Add new types to migrate.id endpoint 

### DIFF
--- a/apiary.apib
+++ b/apiary.apib
@@ -3213,21 +3213,21 @@ Translates an ID from the deprecated API into a new UUID.
         + type: `contact` (enum[string])
             + Members
                 + account
-                + user
-                + product
-                + contact
+                + call
                 + company
+                + contact
+                + creditNote
                 + deal
                 + dealPhase
-                + project
-                + milestone
-                + task
-                + meeting
-                + call
-                + ticket
                 + invoice
-                + creditNote
+                + meeting
+                + milestone
+                + product
+                + project
                 + subscription
+                + task
+                + ticket
+                + user
         + id: `1` (number)
 
 + Response 200 (application/json)

--- a/apiary.apib
+++ b/apiary.apib
@@ -3237,20 +3237,20 @@ Translates an ID from the deprecated API into a new UUID.
             + type: `contact` (enum[string])
                 + Members
                     + account
-                    + user
-                    + product
-                    + contact
                     + company
+                    + contact
+                    + creditNote
+                    + customFieldDefinition
                     + deal
                     + dealPhase
-                    + project
-                    + milestone
-                    + todo
                     + event
-                    + ticket
                     + invoice
-                    + creditNote
-                    + subscription
+                    + milestone
+                    + product
+                    + project
+                    + timeTracking
+                    + todo
+                    + user
             + id: `6ad54ec6-ee2d-4500-afe6-0917c1aa7a38` (string)
 
 ### migrate.taxRate [GET /migrate.taxRate]

--- a/apiary.apib
+++ b/apiary.apib
@@ -3217,6 +3217,7 @@ Translates an ID from the deprecated API into a new UUID.
                 + company
                 + contact
                 + creditNote
+                + customField
                 + deal
                 + dealPhase
                 + invoice

--- a/apiary.apib
+++ b/apiary.apib
@@ -3225,10 +3225,8 @@ Translates an ID from the deprecated API into a new UUID.
                 + milestone
                 + product
                 + project
-                + subscription
                 + task
                 + timeTracking
-                + ticket
                 + user
         + id: `1` (number)
 

--- a/apiary.apib
+++ b/apiary.apib
@@ -3226,6 +3226,7 @@ Translates an ID from the deprecated API into a new UUID.
                 + project
                 + subscription
                 + task
+                + timeTracking
                 + ticket
                 + user
         + id: `1` (number)

--- a/src/99-other/migrating.apib
+++ b/src/99-other/migrating.apib
@@ -25,10 +25,8 @@ Translates an ID from the deprecated API into a new UUID.
                 + milestone
                 + product
                 + project
-                + subscription
                 + task
                 + timeTracking
-                + ticket
                 + user
         + id: `1` (number)
 

--- a/src/99-other/migrating.apib
+++ b/src/99-other/migrating.apib
@@ -37,20 +37,20 @@ Translates an ID from the deprecated API into a new UUID.
             + type: `contact` (enum[string])
                 + Members
                     + account
-                    + user
-                    + product
-                    + contact
                     + company
+                    + contact
+                    + creditNote
+                    + customFieldDefinition
                     + deal
                     + dealPhase
-                    + project
-                    + milestone
-                    + todo
                     + event
-                    + ticket
                     + invoice
-                    + creditNote
-                    + subscription
+                    + milestone
+                    + product
+                    + project
+                    + timeTracking
+                    + todo
+                    + user
             + id: `6ad54ec6-ee2d-4500-afe6-0917c1aa7a38` (string)
 
 ### migrate.taxRate [GET /migrate.taxRate]

--- a/src/99-other/migrating.apib
+++ b/src/99-other/migrating.apib
@@ -26,6 +26,7 @@ Translates an ID from the deprecated API into a new UUID.
                 + project
                 + subscription
                 + task
+                + timeTracking
                 + ticket
                 + user
         + id: `1` (number)

--- a/src/99-other/migrating.apib
+++ b/src/99-other/migrating.apib
@@ -13,21 +13,21 @@ Translates an ID from the deprecated API into a new UUID.
         + type: `contact` (enum[string])
             + Members
                 + account
-                + user
-                + product
-                + contact
+                + call
                 + company
+                + contact
+                + creditNote
                 + deal
                 + dealPhase
-                + project
-                + milestone
-                + task
-                + meeting
-                + call
-                + ticket
                 + invoice
-                + creditNote
+                + meeting
+                + milestone
+                + product
+                + project
                 + subscription
+                + task
+                + ticket
+                + user
         + id: `1` (number)
 
 + Response 200 (application/json)

--- a/src/99-other/migrating.apib
+++ b/src/99-other/migrating.apib
@@ -17,6 +17,7 @@ Translates an ID from the deprecated API into a new UUID.
                 + company
                 + contact
                 + creditNote
+                + customField
                 + deal
                 + dealPhase
                 + invoice


### PR DESCRIPTION
Matching the accepted types with the ones supported at the moment.

Removing supported types is a backward compatibility break.
But a warning is stated in the description of this end-point that that compatibility is not guaranteed.

An alphabetically sorting was done. Better to review commit by commit. 