### PR TITLE
Fix typo in authentication flow

### DIFF
--- a/apiary.apib
+++ b/apiary.apib
@@ -239,7 +239,7 @@ Refresh tokens will continue functioning until the user revokes them or uninstal
 
 Your client secret must remain private and can not be embedded within client side applications such as browser plugins. For these types of applications, we have an alternative authorization method called using the [implicit grant](https://tools.ietf.org/html/rfc6749#section-1.3.2). The implicit grant is a simplified authorization code flow optimized for clients implemented in a browser using a scripting language such as JavaScript. In the implicit flow, instead of issuing the client an authorization code, the client is issued an access token directly.
 
-Similar to the regular flow, users are redirected to the Teamleader authorization page, but use `code` as the `response_type`:
+Similar to the regular flow, users are redirected to the Teamleader authorization page, but use `token` as the `response_type`:
 
 `https://app.teamleader.eu/oauth2/authorize`
 

--- a/apiary.apib
+++ b/apiary.apib
@@ -239,7 +239,7 @@ Refresh tokens will continue functioning until the user revokes them or uninstal
 
 Your client secret must remain private and can not be embedded within client side applications such as browser plugins. For these types of applications, we have an alternative authorization method called using the [implicit grant](https://tools.ietf.org/html/rfc6749#section-1.3.2). The implicit grant is a simplified authorization code flow optimized for clients implemented in a browser using a scripting language such as JavaScript. In the implicit flow, instead of issuing the client an authorization code, the client is issued an access token directly.
 
-Similar to the regular flow, users are redirected to the Teamleader authorization page, but use `token` as the `response_type`:
+Similar to the regular flow, users are redirected to the Teamleader authorization page, but use `code` as the `response_type`:
 
 `https://app.teamleader.eu/oauth2/authorize`
 

--- a/src/authentication.apib
+++ b/src/authentication.apib
@@ -96,7 +96,7 @@ Refresh tokens will continue functioning until the user revokes them or uninstal
 
 Your client secret must remain private and can not be embedded within client side applications such as browser plugins. For these types of applications, we have an alternative authorization method called using the [implicit grant](https://tools.ietf.org/html/rfc6749#section-1.3.2). The implicit grant is a simplified authorization code flow optimized for clients implemented in a browser using a scripting language such as JavaScript. In the implicit flow, instead of issuing the client an authorization code, the client is issued an access token directly.
 
-Similar to the regular flow, users are redirected to the Teamleader authorization page, but use `code` as the `response_type`:
+Similar to the regular flow, users are redirected to the Teamleader authorization page, but use `token` as the `response_type`:
 
 `https://app.teamleader.eu/oauth2/authorize`
 


### PR DESCRIPTION
When using the implicit grant, we need a `response_type = "token"` rather than `response_type = "code"` in the request.