### PR TITLE
Add levelTwoAreas.list endpoint

### DIFF
--- a/apiary.apib
+++ b/apiary.apib
@@ -1304,7 +1304,7 @@ Get a list of tags.
             + (object)
                 + tag: `campaign` (string)
 
-## Addressess [/levelTwoAreas]
+## Addresses [/levelTwoAreas]
 
 We provide a set of data which can be used to build addresses.
 

--- a/apiary.apib
+++ b/apiary.apib
@@ -1304,6 +1304,28 @@ Get a list of tags.
             + (object)
                 + tag: `campaign` (string)
 
+## Addressess [/levelTwoAreas]
+
+We provide a set of data which can be used to build addresses
+
+### levelTwoAreas.list [GET /levelTwoAreas.list]
+
+Gets all level two areas (which correspond to provinces, departments or states in most countries).
+
++ Request (application/json;charset=utf-8)
+
+    + Attributes (object)
+        + country: `BE` (string, required)
+        + language: `nl` (string, optional) - if not passed, we return the name in the primary language of the country
+
++ Response 200 (application/json;charset=utf-8)
+
+    + Attributes (object)
+        + data (array[object])
+            + id: `fd48d4a3-b9dc-4eac-8071-5889c9f21e5d` (string)
+            + name: `West-Vlaanderen` (string)
+            + country: `BE` (string)
+
 # Group Deals
 
 ## Deals [/deals]

--- a/apiary.apib
+++ b/apiary.apib
@@ -1306,17 +1306,17 @@ Get a list of tags.
 
 ## Addressess [/levelTwoAreas]
 
-We provide a set of data which can be used to build addresses
+We provide a set of data which can be used to build addresses.
 
 ### levelTwoAreas.list [GET /levelTwoAreas.list]
 
-Gets all level two areas (which correspond to provinces, departments or states in most countries).
+Get a list of level two areas (which correspond to provinces, departments or states in most countries).
 
 + Request (application/json;charset=utf-8)
 
     + Attributes (object)
         + country: `BE` (string, required)
-        + language: `nl` (string, optional) - if not passed, we return the name in the primary language of the country
+        + language: `nl` (string, optional) - if not passed, the name is returned in the primary language of the country
 
 + Response 200 (application/json;charset=utf-8)
 

--- a/src/02-crm/addresses.apib
+++ b/src/02-crm/addresses.apib
@@ -1,0 +1,21 @@
+## Addressess [/levelTwoAreas]
+
+We provide a set of data which can be used to build addresses
+
+### levelTwoAreas.list [GET /levelTwoAreas.list]
+
+Gets all level two areas (which correspond to provinces, departments or states in most countries).
+
++ Request (application/json;charset=utf-8)
+
+    + Attributes (object)
+        + country: `BE` (string, required)
+        + language: `nl` (string, optional) - if not passed, we return the name in the primary language of the country
+
++ Response 200 (application/json;charset=utf-8)
+
+    + Attributes (object)
+        + data (array[object])
+            + id: `fd48d4a3-b9dc-4eac-8071-5889c9f21e5d` (string)
+            + name: `West-Vlaanderen` (string)
+            + country: `BE` (string)

--- a/src/02-crm/addresses.apib
+++ b/src/02-crm/addresses.apib
@@ -1,6 +1,6 @@
 ## Addressess [/levelTwoAreas]
 
-We provide a set of data which can be used to build addresses
+We provide a set of data which can be used to build addresses.
 
 ### levelTwoAreas.list [GET /levelTwoAreas.list]
 

--- a/src/02-crm/addresses.apib
+++ b/src/02-crm/addresses.apib
@@ -10,7 +10,7 @@ Get a list of level two areas (which correspond to provinces, departments or sta
 
     + Attributes (object)
         + country: `BE` (string, required)
-        + language: `nl` (string, optional) - if not passed, we return the name in the primary language of the country
+        + language: `nl` (string, optional) - if not passed, the name is returned in the primary language of the country
 
 + Response 200 (application/json;charset=utf-8)
 

--- a/src/02-crm/addresses.apib
+++ b/src/02-crm/addresses.apib
@@ -4,7 +4,7 @@ We provide a set of data which can be used to build addresses.
 
 ### levelTwoAreas.list [GET /levelTwoAreas.list]
 
-Gets all level two areas (which correspond to provinces, departments or states in most countries).
+Get a list of level two areas (which correspond to provinces, departments or states in most countries).
 
 + Request (application/json;charset=utf-8)
 

--- a/src/02-crm/addresses.apib
+++ b/src/02-crm/addresses.apib
@@ -1,4 +1,4 @@
-## Addressess [/levelTwoAreas]
+## Addresses [/levelTwoAreas]
 
 We provide a set of data which can be used to build addresses.
 

--- a/src/apiary.apib
+++ b/src/apiary.apib
@@ -29,6 +29,8 @@ HOST: https://api.teamleader.eu
 
 :[Tags](./02-crm/tags.apib)
 
+:[Addresses](./02-crm/addresses.apib)
+
 # Group Deals
 
 :[Deals](./03-deals/deals.apib)


### PR DESCRIPTION
This endpoint will list up all the level two areas. You can provide it with a language which will be used to translate the names if possible (with a fallback to the primary language of the passed country).

This will enable us to add level two areas to the addresses of contacts and companies.