### PR TITLE
Return the invoiceable user preference

### DIFF
--- a/apiary.apib
+++ b/apiary.apib
@@ -476,6 +476,8 @@ Get the current authenticated user.
                     + tr-TR
             + function: `Sales` (string)
             + time_zone: `Europe/Brussels` (string)
+            + preferences (object)
+                + invoiceable: true (boolean)
 
 ### users.list [GET /users.list]
 

--- a/src/01-general/users.apib
+++ b/src/01-general/users.apib
@@ -38,6 +38,8 @@ Get the current authenticated user.
                     + tr-TR
             + function: `Sales` (string)
             + time_zone: `Europe/Brussels` (string)
+            + preferences (object)
+                + invoiceable: true (boolean)
 
 ### users.list [GET /users.list]
 


### PR DESCRIPTION
Based on https://github.com/teamleadercrm/api/pull/231, we're going to return the `invoiceable` property of a user as a preference in users.me