### PR TITLE
PRO-1464: add profit details to milestone

### DIFF
--- a/apiary.apib
+++ b/apiary.apib
@@ -2927,6 +2927,11 @@ Get a list of project milestones.
                     + Members
                         + open
                         + closed
+                + profit_info (object)
+                    + total_revenue (Money)
+                    + total_costs (Money)
+                    + profit (Money)
+
 
 ### milestones.info [GET /milestones.info]
 
@@ -2954,6 +2959,10 @@ Get details for a single milestone.
                 + Members
                     + open
                     + closed
+            + profit_info (object)
+                + total_revenue (Money)
+                + total_costs (Money)
+                + profit (Money)
 
 ### milestones.create [POST /milestones.create]
 

--- a/src/07-projects/milestones.apib
+++ b/src/07-projects/milestones.apib
@@ -52,6 +52,11 @@ Get a list of project milestones.
                     + Members
                         + open
                         + closed
+                + profit_info (object)
+                    + total_revenue (Money)
+                    + total_costs (Money)
+                    + profit (Money)
+
 
 ### milestones.info [GET /milestones.info]
 
@@ -79,6 +84,10 @@ Get details for a single milestone.
                 + Members
                     + open
                     + closed
+            + profit_info (object)
+                + total_revenue (Money)
+                + total_costs (Money)
+                + profit (Money)
 
 ### milestones.create [POST /milestones.create]
 


### PR DESCRIPTION
### Ticket
Link to ticket: https://teamleader.atlassian.net/browse/PRO-1425

![image](https://user-images.githubusercontent.com/10810561/52704233-c6dde780-2f88-11e9-8ca8-2b0826767f05.png)

In the new profit details design, the profitability details are shown at a milestone level so we need to share this information through the API. This structure mirrors the one at the project level.

### What has been done
- Added profit details at the milestone level