### PR TITLE
Cal-1083 Tasks.update extra fields

### DIFF
--- a/apiary.apib
+++ b/apiary.apib
@@ -3022,6 +3022,9 @@ Update a tasks.
         + id: `00ed6266-a5bd-4aac-a292-2582017b6400` (string, required)
         + description (string, optional)
         + due_at: `2016-02-04T16:44:33+00:00` (string, optional)
+        + work_type_id: `32665afd-1818-0ed3-9e18-a603a3a21b95` (string, optional)
+        + estimated_duration: 3600 (number, optional)
+        + assignee_id: `445adf2b-9b76-077b-8b52-9c1c7c32a601` (string, optional)
 
 + Response 204
 

--- a/src/08-tasks/tasks.apib
+++ b/src/08-tasks/tasks.apib
@@ -61,7 +61,7 @@ Create a new task.
         + description (string, required)
         + due_at: `2016-02-04T16:44:33+00:00` (string, required)
         + work_type_id: `32665afd-1818-0ed3-9e18-a603a3a21b95` (string, required)
-        + estimated_duration: 3600 (number, optional)
+        + estimated_duration: 3600 (number, optional) - In seconds
         + assignee_id: `445adf2b-9b76-077b-8b52-9c1c7c32a601` (string, optional)
 
 + Response 201 (application/json;charset=utf-8)
@@ -82,7 +82,7 @@ Update a tasks.
         + description (string, optional)
         + due_at: `2016-02-04T16:44:33+00:00` (string, optional)
         + work_type_id: `32665afd-1818-0ed3-9e18-a603a3a21b95` (string, optional)
-        + estimated_duration: 3600 (number, optional)
+        + estimated_duration: 3600 (number, optional) - In seconds
         + assignee_id: `445adf2b-9b76-077b-8b52-9c1c7c32a601` (string, optional)
 
 + Response 204

--- a/src/08-tasks/tasks.apib
+++ b/src/08-tasks/tasks.apib
@@ -81,5 +81,8 @@ Update a tasks.
         + id: `00ed6266-a5bd-4aac-a292-2582017b6400` (string, required)
         + description (string, optional)
         + due_at: `2016-02-04T16:44:33+00:00` (string, optional)
+        + work_type_id: `32665afd-1818-0ed3-9e18-a603a3a21b95` (string, optional)
+        + estimated_duration: 3600 (number, optional)
+        + assignee_id: `445adf2b-9b76-077b-8b52-9c1c7c32a601` (string, optional)
 
 + Response 204


### PR DESCRIPTION
### Added
- work_type_id, estimated_duration and assignee_id to tasks.update

Implementation: https://github.com/teamleadercrm/core/pull/8173

## Note
Since we're not ready to release these endpoints yet, we decided to not include the `tasks.apib` in the `src/apiary.apib` file. That way we can iterate on the docs through multiple PRs. Once we're ready to release, we will include `tasks.apib` in `src/apiary.apib`.
