### PR TITLE
Turn estimated_duration into an object with unit and value

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -11,7 +11,7 @@ lint: node_modules
 build: src node_modules
 	docker run -it --init --rm -v $(PWD):/code -w /code node:9 npm run build
 
-preview: node_modules
+preview: build
 	docker run -it --init --rm -v $(PWD):/code -w /code apiaryio/client preview --path=/code/apiary.apib --output=/code/apiary.html
 
 watch: node_modules

--- a/apiary.apib
+++ b/apiary.apib
@@ -314,7 +314,7 @@ This documentation only reflects the latest version of the API.
 If you need to make changes to your client or you want to make use of the latest feature, you might need to upgrade your API version.
 
 You can find your current API version, in the `X-Api-Version` header on any API response.
-The current latest version is **2018-10-30**.
+The current latest version is **2019-01-24**.
 
 After checking the API [changelog](#changelog) to see which endpoints work differently, you can upgrade your API version:
 

--- a/src/08-tasks/tasks.apib
+++ b/src/08-tasks/tasks.apib
@@ -61,7 +61,11 @@ Create a new task.
         + description (string, required)
         + due_at: `2016-02-04T16:44:33+00:00` (string, required)
         + work_type_id: `32665afd-1818-0ed3-9e18-a603a3a21b95` (string, required)
-        + estimated_duration: 3600 (number, optional) - In seconds
+        + estimated_duration (object, optional)
+            + unit: `s` (enum[string], required)
+                + Members
+                    + s - Seconds
+            + value: `60` (number, required)
         + assignee_id: `445adf2b-9b76-077b-8b52-9c1c7c32a601` (string, optional)
 
 + Response 201 (application/json;charset=utf-8)


### PR DESCRIPTION
Following this discussion: https://github.com/teamleadercrm/api/pull/276#pullrequestreview-204258740

Once we agree on this, I will proceed to using it in the other documentation PRs we have open.

Note that the main `apiary.apib` file is not updated here because the Tasks section isn't being rendered, since we don't want to release it yet.