### PR TITLE
Add estimated_duration and work_type to tasks.info and tasks.list.

### DIFF
--- a/src/08-tasks/tasks.apib
+++ b/src/08-tasks/tasks.apib
@@ -31,6 +31,10 @@ Get a list of tasks.
                 + completed: false (boolean)
                 + completed_at: `2016-02-04T16:44:33+00:00` (string)
                 + due_at: `2016-02-04T16:44:33+00:00` (string)
+                + estimated_duration: 3600 (number) - In seconds
+                + work_type (object, nullable)
+                    + type: `workType` (string)
+                    + id: `32665afd-1818-0ed3-9e18-a603a3a21b95` (string)
 
 ### tasks.info [GET /tasks.info]
 
@@ -50,6 +54,10 @@ Get information about a task.
             + completed: false (boolean)
             + completed_at: `2016-02-04T16:44:33+00:00` (string)
             + due_at: `2016-02-04T16:44:33+00:00` (string)
+            + estimated_duration: 3600 (number) - In seconds
+            + work_type (object, nullable)
+                + type: `workType` (string)
+                + id: `32665afd-1818-0ed3-9e18-a603a3a21b95` (string)
 
 ### tasks.create [POST /tasks.create]
 

--- a/src/08-tasks/tasks.apib
+++ b/src/08-tasks/tasks.apib
@@ -31,7 +31,11 @@ Get a list of tasks.
                 + completed: false (boolean)
                 + completed_at: `2016-02-04T16:44:33+00:00` (string)
                 + due_at: `2016-02-04T16:44:33+00:00` (string)
-                + estimated_duration: 3600 (number) - In seconds
+                + estimated_duration (object, optional)
+                    + unit: `s` (enum[string], required)
+                        + Members
+                            + s - Seconds
+                    + value: `60` (number, required)
                 + work_type (object, nullable)
                     + type: `workType` (string)
                     + id: `32665afd-1818-0ed3-9e18-a603a3a21b95` (string)
@@ -54,7 +58,11 @@ Get information about a task.
             + completed: false (boolean)
             + completed_at: `2016-02-04T16:44:33+00:00` (string)
             + due_at: `2016-02-04T16:44:33+00:00` (string)
-            + estimated_duration: 3600 (number) - In seconds
+            + estimated_duration (object, optional)
+                + unit: `s` (enum[string], required)
+                    + Members
+                        + s - Seconds
+                + value: `60` (number, required)
             + work_type (object, nullable)
                 + type: `workType` (string)
                 + id: `32665afd-1818-0ed3-9e18-a603a3a21b95` (string)

--- a/src/08-tasks/tasks.apib
+++ b/src/08-tasks/tasks.apib
@@ -32,10 +32,10 @@ Get a list of tasks.
                 + completed_at: `2016-02-04T16:44:33+00:00` (string)
                 + due_at: `2016-02-04T16:44:33+00:00` (string)
                 + estimated_duration (object)
-                    + unit: `s` (enum[string], required)
+                    + unit: `s` (enum[string])
                         + Members
                             + s - Seconds
-                    + value: `60` (number, required)
+                    + value: `60` (number)
                 + work_type (object, nullable)
                     + type: `workType` (string)
                     + id: `32665afd-1818-0ed3-9e18-a603a3a21b95` (string)
@@ -59,10 +59,10 @@ Get information about a task.
             + completed_at: `2016-02-04T16:44:33+00:00` (string)
             + due_at: `2016-02-04T16:44:33+00:00` (string)
             + estimated_duration (object)
-                + unit: `s` (enum[string], required)
+                + unit: `s` (enum[string])
                     + Members
                         + s - Seconds
-                + value: `60` (number, required)
+                + value: `60` (number)
             + work_type (object, nullable)
                 + type: `workType` (string)
                 + id: `32665afd-1818-0ed3-9e18-a603a3a21b95` (string)

--- a/src/08-tasks/tasks.apib
+++ b/src/08-tasks/tasks.apib
@@ -31,7 +31,7 @@ Get a list of tasks.
                 + completed: false (boolean)
                 + completed_at: `2016-02-04T16:44:33+00:00` (string)
                 + due_at: `2016-02-04T16:44:33+00:00` (string)
-                + estimated_duration (object, optional)
+                + estimated_duration (object)
                     + unit: `s` (enum[string], required)
                         + Members
                             + s - Seconds
@@ -58,7 +58,7 @@ Get information about a task.
             + completed: false (boolean)
             + completed_at: `2016-02-04T16:44:33+00:00` (string)
             + due_at: `2016-02-04T16:44:33+00:00` (string)
-            + estimated_duration (object, optional)
+            + estimated_duration (object)
                 + unit: `s` (enum[string], required)
                     + Members
                         + s - Seconds


### PR DESCRIPTION
Implementation: https://github.com/teamleadercrm/core/pull/8261

## Note
Since we're not ready to release these endpoints yet, we decided to not include the `tasks.apib` in the `src/apiary.apib` file. That way we can iterate on the docs through multiple PRs. Once we're ready to release, we will include `tasks.apib` in `src/apiary.apib`.