### PR TITLE
Use an object for estimated_duration in tasks.update

### DIFF
--- a/src/08-tasks/tasks.apib
+++ b/src/08-tasks/tasks.apib
@@ -105,7 +105,11 @@ Update a tasks.
         + description (string, optional)
         + due_at: `2016-02-04T16:44:33+00:00` (string, optional)
         + work_type_id: `32665afd-1818-0ed3-9e18-a603a3a21b95` (string, optional)
-        + estimated_duration: 3600 (number, optional) - In seconds
+        + estimated_duration (object, optional)
+            + unit: `s` (enum[string], required)
+                + Members
+                    + s - Seconds
+            + value: `60` (number, required)
         + assignee_id: `445adf2b-9b76-077b-8b52-9c1c7c32a601` (string, optional)
 
 + Response 204


### PR DESCRIPTION
Follow-up to https://github.com/teamleadercrm/api/pull/299

https://github.com/teamleadercrm/core/pull/8311

## Note
Since we're not ready to release these endpoints yet, we decided to not include the `tasks.apib` in the `src/apiary.apib` file. That way we can iterate on the docs through multiple PRs. Once we're ready to release, we will include `tasks.apib` in `src/apiary.apib`.