### PR TITLE
Removed responsible_user_id from apib.

### DIFF
--- a/src/08-tasks/tasks.apib
+++ b/src/08-tasks/tasks.apib
@@ -8,7 +8,6 @@ Get a list of tasks.
 
     + Attributes (object)
         + filter (object, optional)
-            + assignee_id: `f29abf48-337d-44b4-aad4-585f5277a456` (string, optional)
             + completed: true (boolean, optional)
         + page (Page, optional)
         + sort (array, optional)
@@ -85,7 +84,6 @@ Create a new task.
                 + Members
                     + s - Seconds
             + value: `60` (number, required)
-        + assignee_id: `445adf2b-9b76-077b-8b52-9c1c7c32a601` (string, optional)
 
 + Response 201 (application/json;charset=utf-8)
 
@@ -106,7 +104,6 @@ Update a tasks.
         + due_at: `2016-02-04T16:44:33+00:00` (string, optional)
         + work_type_id: `32665afd-1818-0ed3-9e18-a603a3a21b95` (string, optional)
         + estimated_duration: 3600 (number, optional) - In seconds
-        + assignee_id: `445adf2b-9b76-077b-8b52-9c1c7c32a601` (string, optional)
 
 + Response 204
 


### PR DESCRIPTION
For now we won't support responsible_user_id on the public API.
We will have to figure out how we're going to proceed regarding the teams on tasks, after that we will put it public.