### PR TITLE
estimated_duration of Tasks must be in minutes

### DIFF
--- a/src/08-tasks/tasks.apib
+++ b/src/08-tasks/tasks.apib
@@ -35,9 +35,9 @@ Get a list of tasks.
                 + completed_at: `2016-02-04T16:44:33+00:00` (string)
                 + due_at: `2016-02-04T16:44:33+00:00` (string)
                 + estimated_duration (object)
-                    + unit: `s` (enum[string])
+                    + unit: `min` (enum[string])
                         + Members
-                            + s - Seconds
+                            + min - Minutes
                     + value: `60` (number)
                 + work_type (object, nullable)
                     + type: `workType` (string)
@@ -62,9 +62,9 @@ Get information about a task.
             + completed_at: `2016-02-04T16:44:33+00:00` (string)
             + due_at: `2016-02-04T16:44:33+00:00` (string)
             + estimated_duration (object)
-                + unit: `s` (enum[string])
+                + unit: `min` (enum[string])
                     + Members
-                        + s - Seconds
+                        + min - Minutes
                 + value: `60` (number)
             + work_type (object, nullable)
                 + type: `workType` (string)
@@ -81,9 +81,9 @@ Create a new task.
         + due_at: `2016-02-04T16:44:33+00:00` (string, required)
         + work_type_id: `32665afd-1818-0ed3-9e18-a603a3a21b95` (string, required)
         + estimated_duration (object, optional)
-            + unit: `s` (enum[string], required)
+            + unit: `min` (enum[string], required)
                 + Members
-                    + s - Seconds
+                    + min - Minutes
             + value: `60` (number, required)
         + assignee_id: `445adf2b-9b76-077b-8b52-9c1c7c32a601` (string, optional)
 
@@ -106,9 +106,9 @@ Update a tasks.
         + due_at: `2016-02-04T16:44:33+00:00` (string, optional)
         + work_type_id: `32665afd-1818-0ed3-9e18-a603a3a21b95` (string, optional)
         + estimated_duration (object, optional)
-            + unit: `s` (enum[string], required)
+            + unit: `min` (enum[string], required)
                 + Members
-                    + s - Seconds
+                    + min - Minutes
             + value: `60` (number, required)
         + assignee_id: `445adf2b-9b76-077b-8b52-9c1c7c32a601` (string, optional)
 


### PR DESCRIPTION
Even though we want to standardise on seconds everywhere, it just doesn't make sense here since in the Web UI we're using minutes. Using seconds on the API would lead to unexpected behaviour since we'd have to round to minutes.

Even though there is no [International System of Units](https://en.wikipedia.org/wiki/International_System_of_Units) unit for minutes, the ad-hoc "standard" is `min`, apparently. There's more information on that wikipedia page.

https://github.com/teamleadercrm/core/pull/8350

## Note
Since we're not ready to release these endpoints yet, we decided to not include the `tasks.apib` in the `src/apiary.apib` file. That way we can iterate on the docs through multiple PRs. Once we're ready to release, we will include `tasks.apib` in `src/apiary.apib`.