### PR TITLE
Adapt API docs for new assignee format

### DIFF
--- a/src/08-tasks/tasks.apib
+++ b/src/08-tasks/tasks.apib
@@ -101,6 +101,7 @@ Create a new task.
             + type: `user` (enum[string])
                 + Members
                     + user
+                    + team
             + id: `f29abf48-337d-44b4-aad4-585f5277a456` (string)
 
 + Response 201 (application/json;charset=utf-8)

--- a/src/08-tasks/tasks.apib
+++ b/src/08-tasks/tasks.apib
@@ -8,7 +8,7 @@ Get a list of tasks.
 
     + Attributes (object)
         + filter (object, optional)
-            + assignee_id: `f29abf48-337d-44b4-aad4-585f5277a456` (string, optional)
+            + user_id: `f29abf48-337d-44b4-aad4-585f5277a456` (string, optional)
             + completed: true (boolean, optional)
         + page (Page, optional)
         + sort (array, optional)
@@ -42,6 +42,12 @@ Get a list of tasks.
                 + work_type (object, nullable)
                     + type: `workType` (string)
                     + id: `32665afd-1818-0ed3-9e18-a603a3a21b95` (string)
+                + responsible (object)
+                    + type: `user` (enum[string])
+                        + Members
+                            + user
+                            + team
+                    + id: `f29abf48-337d-44b4-aad4-585f5277a456` (string)
 
 ### tasks.info [GET /tasks.info]
 
@@ -69,6 +75,12 @@ Get information about a task.
             + work_type (object, nullable)
                 + type: `workType` (string)
                 + id: `32665afd-1818-0ed3-9e18-a603a3a21b95` (string)
+            + responsible (object)
+                + type: `user` (enum[string])
+                    + Members
+                        + user
+                        + team
+                + id: `f29abf48-337d-44b4-aad4-585f5277a456` (string)
 
 ### tasks.create [POST /tasks.create]
 
@@ -85,7 +97,11 @@ Create a new task.
                 + Members
                     + s - Seconds
             + value: `60` (number, required)
-        + assignee_id: `445adf2b-9b76-077b-8b52-9c1c7c32a601` (string, optional)
+        + responsible (object, optional)
+            + type: `user` (enum[string])
+                + Members
+                    + user
+            + id: `f29abf48-337d-44b4-aad4-585f5277a456` (string)
 
 + Response 201 (application/json;charset=utf-8)
 
@@ -110,7 +126,11 @@ Update a tasks.
                 + Members
                     + s - Seconds
             + value: `60` (number, required)
-        + assignee_id: `445adf2b-9b76-077b-8b52-9c1c7c32a601` (string, optional)
+        + responsible (object, optional)
+            + type: `user` (enum[string])
+                + Members
+                    + user
+            + id: `f29abf48-337d-44b4-aad4-585f5277a456` (string)
 
 + Response 204
 

--- a/src/08-tasks/tasks.apib
+++ b/src/08-tasks/tasks.apib
@@ -130,6 +130,7 @@ Update a tasks.
             + type: `user` (enum[string])
                 + Members
                     + user
+                    + team
             + id: `f29abf48-337d-44b4-aad4-585f5277a456` (string)
 
 + Response 204

--- a/src/08-tasks/tasks.apib
+++ b/src/08-tasks/tasks.apib
@@ -8,7 +8,7 @@ Get a list of tasks.
 
     + Attributes (object)
         + filter (object, optional)
-            + user_id: `f29abf48-337d-44b4-aad4-585f5277a456` (string, optional)
+            + user_id: `f29abf48-337d-44b4-aad4-585f5277a456` (string, optional) - Returns Tasks that are assigned to this user or to a team to which this user belongs.
             + completed: true (boolean, optional)
         + page (Page, optional)
         + sort (array, optional)

--- a/src/08-tasks/tasks.apib
+++ b/src/08-tasks/tasks.apib
@@ -42,7 +42,7 @@ Get a list of tasks.
                 + work_type (object, nullable)
                     + type: `workType` (string)
                     + id: `32665afd-1818-0ed3-9e18-a603a3a21b95` (string)
-                + assigned_to (object)
+                + assignee (object)
                     + type: `user` (enum[string])
                         + Members
                             + user
@@ -75,7 +75,7 @@ Get information about a task.
             + work_type (object, nullable)
                 + type: `workType` (string)
                 + id: `32665afd-1818-0ed3-9e18-a603a3a21b95` (string)
-            + assigned_to (object)
+            + assignee (object)
                 + type: `user` (enum[string])
                     + Members
                         + user
@@ -97,7 +97,7 @@ Create a new task.
                 + Members
                     + min - Minutes
             + value: `60` (number, required)
-        + assigned_to (object, optional)
+        + assignee (object, optional)
             + type: `user` (enum[string])
                 + Members
                     + user
@@ -127,7 +127,7 @@ Update a tasks.
                 + Members
                     + min - Minutes
             + value: `60` (number, required)
-        + assigned_to (object, optional)
+        + assignee (object, optional)
             + type: `user` (enum[string])
                 + Members
                     + user

--- a/src/08-tasks/tasks.apib
+++ b/src/08-tasks/tasks.apib
@@ -42,7 +42,7 @@ Get a list of tasks.
                 + work_type (object, nullable)
                     + type: `workType` (string)
                     + id: `32665afd-1818-0ed3-9e18-a603a3a21b95` (string)
-                + responsible (object)
+                + assigned_to (object)
                     + type: `user` (enum[string])
                         + Members
                             + user
@@ -75,7 +75,7 @@ Get information about a task.
             + work_type (object, nullable)
                 + type: `workType` (string)
                 + id: `32665afd-1818-0ed3-9e18-a603a3a21b95` (string)
-            + responsible (object)
+            + assigned_to (object)
                 + type: `user` (enum[string])
                     + Members
                         + user
@@ -97,7 +97,7 @@ Create a new task.
                 + Members
                     + s - Seconds
             + value: `60` (number, required)
-        + responsible (object, optional)
+        + assigned_to (object, optional)
             + type: `user` (enum[string])
                 + Members
                     + user
@@ -127,7 +127,7 @@ Update a tasks.
                 + Members
                     + s - Seconds
             + value: `60` (number, required)
-        + responsible (object, optional)
+        + assigned_to (object, optional)
             + type: `user` (enum[string])
                 + Members
                     + user


### PR DESCRIPTION
Teams are not part of this PR, but we will add it later.
 
- tasks.list
	- `user_id` filter - be able to get tasks where the `user_id` is the responsible or is part of the responsible team.
	- response returns the `assignee` object.
- tasks.info
	- response returns the `assignee` object.
- tasks.create
	- accept `assignee` object instead of `assignee_id`
	- only accept assignee of type `user`
- tasks.update
	- accept `assignee` object instead of `assignee_id`
	- only accept `assignee` of type `user`