### PR TITLE
Add tax rate uuid to quotation.info endpoint

### DIFF
--- a/apiary.apib
+++ b/apiary.apib
@@ -314,7 +314,7 @@ This documentation only reflects the latest version of the API.
 If you need to make changes to your client or you want to make use of the latest feature, you might need to upgrade your API version.
 
 You can find your current API version, in the `X-Api-Version` header on any API response.
-The current latest version is **2018-10-30**.
+The current latest version is **2019-03-13**.
 
 After checking the API [changelog](#changelog) to see which endpoints work differently, you can upgrade your API version:
 
@@ -326,6 +326,10 @@ _This will only affect the version for those API calls and won't affect any othe
 ### Changelog
 
 We list all backwards-incompatible changes here. As described above, new additions and forwards-compatible changes don’t need a new API version and will not appear in this list.
+
+#### 2019-03-13
+- The property `tax` in the `quotations.info` endpoint previously returned the tax `rate`, this has been changed to return `type` and `id` of the tax
+
 
 #### 2019-01-24
 
@@ -1713,7 +1717,8 @@ Get a quotation
                                     + Members
                                         + excluding
                             + tax (object)
-                                + rate: 0.21 (number)
+                                + type: `taxRate` (string)
+                                + id: `e2314517-3cab-4aa9-8471-450e73449042` (string)
                             + discount (object, nullable)
                                 + type: `percentage` (enum[string])
                                     + Members

--- a/src/03-deals/quotations.apib
+++ b/src/03-deals/quotations.apib
@@ -39,7 +39,8 @@ Get a quotation
                                     + Members
                                         + excluding
                             + tax (object)
-                                + rate: 0.21 (number)
+                                + type: `taxRate` (string)
+                                + id: `e2314517-3cab-4aa9-8471-450e73449042` (string)
                             + discount (object, nullable)
                                 + type: `percentage` (enum[string])
                                     + Members

--- a/src/changes.apib
+++ b/src/changes.apib
@@ -50,6 +50,7 @@ We list all backwards-incompatible changes here. As described above, new additio
 
 #### 2019-03-13
 
+- The property `tax` in the `quotations.info` endpoint previously returned the tax `rate`, this has been changed to return `type` and `id` of the tax
 
 
 #### 2019-01-24


### PR DESCRIPTION
Bookkeeping integrations need to have more details regarding the Tax Rate. The percentage is not enough since the same percentage value can have different meanings. By exposing the Tax Rate ID we give them the possibility to fetch more details of that given Tax Rate.

This change implies the removal of the `rate` from the `tax` object in `quotations.info` response. In exchange, we are adding the `id` and the `type` to that object. That way Integrators will be able to fetch the details of the Tax Rate.