### PR TITLE
Add BC break for products.list endpoint

### DIFF
--- a/apiary.apib
+++ b/apiary.apib
@@ -314,7 +314,7 @@ This documentation only reflects the latest version of the API.
 If you need to make changes to your client or you want to make use of the latest feature, you might need to upgrade your API version.
 
 You can find your current API version, in the `X-Api-Version` header on any API response.
-The current latest version is **2018-10-30**.
+The current latest version is **2019-03-13**.
 
 After checking the API [changelog](#changelog) to see which endpoints work differently, you can upgrade your API version:
 
@@ -326,6 +326,12 @@ _This will only affect the version for those API calls and won't affect any othe
 ### Changelog
 
 We list all backwards-incompatible changes here. As described above, new additions and forwards-compatible changes don’t need a new API version and will not appear in this list.
+
+#### 2019-03-13
+
+- Product `name` and `description` are no longer wrapped in a `translations` object.
+- Product `external_id` was renamed to `code`.
+
 
 #### 2019-01-24
 
@@ -2632,7 +2638,7 @@ Get a list of products.
     + Attributes (object)
         + filter (object, optional)
             + ids: `bbbfe0da-e692-4ee3-9d3d-0716808d6523`,`722e1eb9-53d5-4b8c-9d17-154dcc65c610` (array[string], optional)
-            + term: `cookies` (string, optional) - The name and the external id.
+            + term: `cookies` (string, optional) - Will filter on the name or the code.
 
 + Response 200 (application/json;charset=utf-8)
 
@@ -2640,11 +2646,9 @@ Get a list of products.
         + data (array)
             + (object)
                 + id: `2aa4a6a9-9ce8-4851-a9b3-26aea2ea14c4` (string)
-                + translations (array)
-                    + (object)
-                        + name: `cookies` (string)
-                        + description: `dark chocolate` (string)
-                + external_id: `123` (string)
+                + name: `cookies` (string)
+                + description: `dark chocolate` (string)
+                + code: `123` (string)
 
 # Group Projects
 

--- a/apiary.apib
+++ b/apiary.apib
@@ -329,8 +329,8 @@ We list all backwards-incompatible changes here. As described above, new additio
 
 #### 2019-03-13
 
-- Product `name` and `description` are no longer wrapped in a `translations` object.
-- Product `external_id` was renamed to `code`.
+- Product `name` and `description` are no longer wrapped in a `translations` object in `/products.list`.
+- Product `external_id` was renamed to `code` in `/products.list`.
 
 
 #### 2019-01-24

--- a/src/06-products/products.apib
+++ b/src/06-products/products.apib
@@ -11,7 +11,7 @@ Get a list of products.
     + Attributes (object)
         + filter (object, optional)
             + ids: `bbbfe0da-e692-4ee3-9d3d-0716808d6523`,`722e1eb9-53d5-4b8c-9d17-154dcc65c610` (array[string], optional)
-            + term: `cookies` (string, optional) - The name and the external id.
+            + term: `cookies` (string, optional) - Will filter on the name or the code.
 
 + Response 200 (application/json;charset=utf-8)
 
@@ -19,8 +19,6 @@ Get a list of products.
         + data (array)
             + (object)
                 + id: `2aa4a6a9-9ce8-4851-a9b3-26aea2ea14c4` (string)
-                + translations (array)
-                    + (object)
-                        + name: `cookies` (string)
-                        + description: `dark chocolate` (string)
-                + external_id: `123` (string)
+                + name: `cookies` (string)
+                + description: `dark chocolate` (string)
+                + code: `123` (string)

--- a/src/changes.apib
+++ b/src/changes.apib
@@ -50,6 +50,8 @@ We list all backwards-incompatible changes here. As described above, new additio
 
 #### 2019-03-13
 
+- Product `name` and `description` are no longer wrapped in a `translations` object.
+- Product `external_id` was renamed to `code`.
 
 
 #### 2019-01-24

--- a/src/changes.apib
+++ b/src/changes.apib
@@ -50,8 +50,8 @@ We list all backwards-incompatible changes here. As described above, new additio
 
 #### 2019-03-13
 
-- Product `name` and `description` are no longer wrapped in a `translations` object.
-- Product `external_id` was renamed to `code`.
+- Product `name` and `description` are no longer wrapped in a `translations` object in `/products.list`.
+- Product `external_id` was renamed to `code` in `/products.list`.
 
 
 #### 2019-01-24


### PR DESCRIPTION
### Added
- A description of changes to `/products.list`

### Changed
- `name` and `description` are no longer wrapped in `translations` in `/products.list`
- `external_id` was renamed to `code` in `/products.list`