### PR TITLE
[PRO-1717] New API filter for project items: internal_cost_per_unit 

### DIFF
--- a/src/07-projects/project-items.apib
+++ b/src/07-projects/project-items.apib
@@ -19,6 +19,7 @@ Get a list of project items.
                     + external_cost_item
                     + time_tracking_product
             + milestone_id: `944534fb-15f1-4eea-aab1-82a427aa2d0d` (string, optional)
+            + internal_cost_per_unit: null (nullable, optional)
         + page (Page, optional)
         + sort (array, optional)
             + (object)


### PR DESCRIPTION
### Ticket
Link to ticket: https://teamleader.atlassian.net/browse/PRO-1717

We need to identify all project items inside a project that don't have a value for the internal cost per unit, so that we can ask our customers to input this value before seeing the profit for the project.

So we have added a new filter (`internal_cost_per_unit`) that only accepts null as value (for now, at least).

Implementation PR: https://github.com/teamleadercrm/core/pull/9118
E2E tests PR: https://github.com/teamleadercrm/api-tests/pull/583