### PR TITLE
[PRO-1726] API documentation for adding a product reference to project items

### DIFF
--- a/src/07-projects/project-items.apib
+++ b/src/07-projects/project-items.apib
@@ -70,6 +70,9 @@ Get a list of project items.
                 + total
                     + internal_cost (Money)
                     + billable_price (Money)
+                + product (object, nullable)
+                    + type: `product` (string)
+                    + id: `e2314517-3cab-4aa9-8471-450e73449040` (string)
                 + added_at: `2018-12-04T16:44:33+00:00` (string)
                 + updated_at: `2018-12-05T16:44:33+00:00` (string)
         + meta (object)
@@ -113,5 +116,8 @@ Get details for a single project item.
             + total
                 + internal_cost (Money)
                 + billable_price (Money)
+            + product (object, nullable)
+                + type: `product` (string)
+                + id: `e2314517-3cab-4aa9-8471-450e73449040` (string)
             + added_at: `2018-12-04T16:44:33+00:00` (string)
             + updated_at: `2018-12-05T16:44:33+00:00` (string)


### PR DESCRIPTION
### Ticket
Link to ticket: https://teamleader.atlassian.net/browse/PRO-1726

Implementation PR: https://github.com/teamleadercrm/core/pull/9255
E2E tests PR: https://github.com/teamleadercrm/api-tests/pull/591

In the case of project items that don't have a purchase price set, we want to suggest the purchase price of the referenced product (where applicable). So we're going to expose the related product, so that they could be sideloaded.

### What has been done
- Added a product reference to project items