### PR TITLE
PRO-1749: add users.update endpoint documentation

### DIFF
--- a/apiary.apib
+++ b/apiary.apib
@@ -626,15 +626,15 @@ Get details for a single user.
             + time_zone: `Europe/Brussels` (string)
 
 
-### users.update [POST /users.update]
+### users.updateInternalHourlyCost [POST /users.updateInternalHourlyCost]
 
 Update details for a single user.
 
 + Request (application/json;charset=utf-8)
 
     + Attributes (object)
-        + user_id: `b5094b3f-bb7a-0391-b01b-e709773f3509` (string)
-        + internal_rate (object, nullable)
+        + id: `b5094b3f-bb7a-0391-b01b-e709773f3509` (string)
+        + internal_hourly_cost (object, nullable)
             + value (Money)
 
 + Response 204 (application/json;charset=utf-8)

--- a/apiary.apib
+++ b/apiary.apib
@@ -625,6 +625,22 @@ Get details for a single user.
             + function: `Sales` (string)
             + time_zone: `Europe/Brussels` (string)
 
+
+### users.updateRates [POST /users.updateRates]
+
+Update user rates used for timetracking.
+
++ Request (application/json;charset=utf-8)
+
+    + Attributes (object)
+        + user_id: `b5094b3f-bb7a-0391-b01b-e709773f3509` (string)
+        + internal_rate (object, nullable)
+            + value (Money)
+        + billable_price (object, nullable)
+            + value (Money)
+
++ Response 204 (application/json;charset=utf-8)
+
 ## Custom Fields [/customFieldDefinitions]
 
 Custom fields are used to add additional data/properties to entities within Teamleader.

--- a/apiary.apib
+++ b/apiary.apib
@@ -626,17 +626,15 @@ Get details for a single user.
             + time_zone: `Europe/Brussels` (string)
 
 
-### users.updateRates [POST /users.updateRates]
+### users.update [POST /users.update]
 
-Update user rates used for timetracking.
+Update details for a single user.
 
 + Request (application/json;charset=utf-8)
 
     + Attributes (object)
         + user_id: `b5094b3f-bb7a-0391-b01b-e709773f3509` (string)
         + internal_rate (object, nullable)
-            + value (Money)
-        + billable_price (object, nullable)
             + value (Money)
 
 + Response 204 (application/json;charset=utf-8)

--- a/src/01-general/users.apib
+++ b/src/01-general/users.apib
@@ -120,3 +120,15 @@ Get details for a single user.
                     + tr-TR
             + function: `Sales` (string)
             + time_zone: `Europe/Brussels` (string)
+
+
+### users.updateRates [POST /users.updateRates]
+
+Update user rates used for timetracking
+
++ Request (application/json;charset=utf-8)
+
+    + Attributes (object)
+        + user_id: `b5094b3f-bb7a-0391-b01b-e709773f3509` (string)
+        + internal_cost (Money, nullable)
+        + billable_price (Money, nullable)

--- a/src/01-general/users.apib
+++ b/src/01-general/users.apib
@@ -132,3 +132,5 @@ Update user rates used for timetracking
         + user_id: `b5094b3f-bb7a-0391-b01b-e709773f3509` (string)
         + internal_cost (Money, nullable)
         + billable_price (Money, nullable)
+
++ Response 204 (application/json;charset=utf-8)

--- a/src/01-general/users.apib
+++ b/src/01-general/users.apib
@@ -122,15 +122,15 @@ Get details for a single user.
             + time_zone: `Europe/Brussels` (string)
 
 
-### users.update [POST /users.update]
+### users.updateInternalHourlyCost [POST /users.updateInternalHourlyCost]
 
 Update details for a single user.
 
 + Request (application/json;charset=utf-8)
 
     + Attributes (object)
-        + user_id: `b5094b3f-bb7a-0391-b01b-e709773f3509` (string)
-        + internal_rate (object, nullable)
+        + id: `b5094b3f-bb7a-0391-b01b-e709773f3509` (string)
+        + internal_hourly_cost (object, nullable)
             + value (Money)
 
 + Response 204 (application/json;charset=utf-8)

--- a/src/01-general/users.apib
+++ b/src/01-general/users.apib
@@ -124,13 +124,15 @@ Get details for a single user.
 
 ### users.updateRates [POST /users.updateRates]
 
-Update user rates used for timetracking
+Update user rates used for timetracking.
 
 + Request (application/json;charset=utf-8)
 
     + Attributes (object)
         + user_id: `b5094b3f-bb7a-0391-b01b-e709773f3509` (string)
-        + internal_cost (Money, nullable)
-        + billable_price (Money, nullable)
+        + internal_rate (object, nullable)
+            + value (Money)
+        + billable_price (object, nullable)
+            + value (Money)
 
 + Response 204 (application/json;charset=utf-8)

--- a/src/01-general/users.apib
+++ b/src/01-general/users.apib
@@ -122,17 +122,15 @@ Get details for a single user.
             + time_zone: `Europe/Brussels` (string)
 
 
-### users.updateRates [POST /users.updateRates]
+### users.update [POST /users.update]
 
-Update user rates used for timetracking.
+Update details for a single user.
 
 + Request (application/json;charset=utf-8)
 
     + Attributes (object)
         + user_id: `b5094b3f-bb7a-0391-b01b-e709773f3509` (string)
         + internal_rate (object, nullable)
-            + value (Money)
-        + billable_price (object, nullable)
             + value (Money)
 
 + Response 204 (application/json;charset=utf-8)


### PR DESCRIPTION
⚠️ DO NOT MERGE - `internal_rate` property is part of "profit on projects" feature flag, not yet publicly released.

Document new endpoint `user.update`, which - for now - allows specifying a users's internal rate.
