### PR TITLE
[PRO-1750] Add totals to project items list

### DIFF
--- a/src/07-projects/project-items.apib
+++ b/src/07-projects/project-items.apib
@@ -40,6 +40,7 @@ Get a list of project items.
                 + (object)
                     + field: `occurred_at`
                     + order: `desc`
+        + withTotals: false (boolean, optional)
 
 + Response 200 (application/json;charset=utf-8)
 
@@ -78,6 +79,10 @@ Get a list of project items.
         + meta (object)
             + page (Pagination)
             + matches: `120` (number)
+            + totals (object, optional) - Only available when withTotals is true in the request parameters
+                + revenue (Money)
+                + costs (Money)
+                + result (Money)
 
 ### projectItems.info [GET /projectItems.info]
 

--- a/src/07-projects/project-items.apib
+++ b/src/07-projects/project-items.apib
@@ -40,7 +40,6 @@ Get a list of project items.
                 + (object)
                     + field: `occurred_at`
                     + order: `desc`
-        + include_totals: false (boolean, optional)
 
 + Response 200 (application/json;charset=utf-8)
 
@@ -79,7 +78,7 @@ Get a list of project items.
         + meta (object)
             + page (Pagination)
             + matches: `120` (number)
-            + totals (object, optional) - Only available when include_totals is true in the request parameters
+            + totals (object)
                 + revenue (Money)
                 + costs (Money)
                 + result (Money)

--- a/src/07-projects/project-items.apib
+++ b/src/07-projects/project-items.apib
@@ -40,7 +40,7 @@ Get a list of project items.
                 + (object)
                     + field: `occurred_at`
                     + order: `desc`
-        + withTotals: false (boolean, optional)
+        + include_totals: false (boolean, optional)
 
 + Response 200 (application/json;charset=utf-8)
 
@@ -79,7 +79,7 @@ Get a list of project items.
         + meta (object)
             + page (Pagination)
             + matches: `120` (number)
-            + totals (object, optional) - Only available when withTotals is true in the request parameters
+            + totals (object, optional) - Only available when include_totals is true in the request parameters
                 + revenue (Money)
                 + costs (Money)
                 + result (Money)


### PR DESCRIPTION
### Ticket
Link to ticket: https://teamleader.atlassian.net/browse/PRO-1750

The new project profit screen groups project items by user or by task type. Inside each group, they are further grouped by milestone. So we can't use the aggregate milestone values that we initially designed. We need to add the totals in the list endpoint and calculate them based on the current filter.

However, since calculating the totals may be a database intensive action, we want to only trigger this if the API consumer really wants it, hence we have added a `withTotals` parameter to the call. If this is set and is true, the `meta` section will contain a `totals` object that reflects the same structure as `projects.info` and `milestones.info`.