### PR TITLE
document new users.updateInternalHourlyCost endpoint

### DIFF
--- a/apiary.apib
+++ b/apiary.apib
@@ -628,7 +628,7 @@ Get details for a single user.
 
 ### users.updateInternalHourlyCost [POST /users.updateInternalHourlyCost]
 
-Update the internal hourly cost for a single user.
+Update the internal hourly cost for a single user. Only account administrators can set the internal hourly cost of a user.
 
 + Request (application/json;charset=utf-8)
 

--- a/apiary.apib
+++ b/apiary.apib
@@ -625,6 +625,20 @@ Get details for a single user.
             + function: `Sales` (string)
             + time_zone: `Europe/Brussels` (string)
 
+
+### users.updateInternalHourlyCost [POST /users.updateInternalHourlyCost]
+
+Update details for a single user.
+
++ Request (application/json;charset=utf-8)
+
+    + Attributes (object)
+        + id: `b5094b3f-bb7a-0391-b01b-e709773f3509` (string)
+        + internal_hourly_cost (object, nullable)
+            + value (Money)
+
++ Response 204 (application/json;charset=utf-8)
+
 ## Custom Fields [/customFieldDefinitions]
 
 Custom fields are used to add additional data/properties to entities within Teamleader.

--- a/apiary.apib
+++ b/apiary.apib
@@ -634,8 +634,7 @@ Update details for a single user.
 
     + Attributes (object)
         + id: `b5094b3f-bb7a-0391-b01b-e709773f3509` (string)
-        + internal_hourly_cost (object, nullable)
-            + value (Money)
+        + internal_hourly_cost (Money, nullable)
 
 + Response 204 (application/json;charset=utf-8)
 

--- a/apiary.apib
+++ b/apiary.apib
@@ -628,7 +628,7 @@ Get details for a single user.
 
 ### users.updateInternalHourlyCost [POST /users.updateInternalHourlyCost]
 
-Update details for a single user.
+Update the internal hourly cost for a single user.
 
 + Request (application/json;charset=utf-8)
 

--- a/apiary.apib
+++ b/apiary.apib
@@ -628,14 +628,13 @@ Get details for a single user.
 
 ### users.updateInternalHourlyCost [POST /users.updateInternalHourlyCost]
 
-Update details for a single user.
+Update the internal hourly cost for a single user.
 
 + Request (application/json;charset=utf-8)
 
     + Attributes (object)
         + id: `b5094b3f-bb7a-0391-b01b-e709773f3509` (string)
-        + internal_hourly_cost (object, nullable)
-            + value (Money)
+        + internal_hourly_cost (Money, nullable)
 
 + Response 204 (application/json;charset=utf-8)
 

--- a/apiary.apib
+++ b/apiary.apib
@@ -634,7 +634,7 @@ Update the internal hourly cost for a single user. Only account administrators c
 
     + Attributes (object)
         + id: `b5094b3f-bb7a-0391-b01b-e709773f3509` (string)
-        + internal_hourly_cost (Money, nullable)
+        + internal_hourly_cost (Money)
 
 + Response 204 (application/json;charset=utf-8)
 

--- a/src/01-general/users.apib
+++ b/src/01-general/users.apib
@@ -130,7 +130,6 @@ Update details for a single user.
 
     + Attributes (object)
         + id: `b5094b3f-bb7a-0391-b01b-e709773f3509` (string)
-        + internal_hourly_cost (object, nullable)
-            + value (Money)
+        + internal_hourly_cost (Money, nullable)
 
 + Response 204 (application/json;charset=utf-8)

--- a/src/01-general/users.apib
+++ b/src/01-general/users.apib
@@ -124,7 +124,7 @@ Get details for a single user.
 
 ### users.updateInternalHourlyCost [POST /users.updateInternalHourlyCost]
 
-Update details for a single user.
+Update the internal hourly cost for a single user.
 
 + Request (application/json;charset=utf-8)
 

--- a/src/01-general/users.apib
+++ b/src/01-general/users.apib
@@ -124,13 +124,12 @@ Get details for a single user.
 
 ### users.updateInternalHourlyCost [POST /users.updateInternalHourlyCost]
 
-Update details for a single user.
+Update the internal hourly cost for a single user.
 
 + Request (application/json;charset=utf-8)
 
     + Attributes (object)
         + id: `b5094b3f-bb7a-0391-b01b-e709773f3509` (string)
-        + internal_hourly_cost (object, nullable)
-            + value (Money)
+        + internal_hourly_cost (Money, nullable)
 
 + Response 204 (application/json;charset=utf-8)

--- a/src/01-general/users.apib
+++ b/src/01-general/users.apib
@@ -124,7 +124,7 @@ Get details for a single user.
 
 ### users.updateInternalHourlyCost [POST /users.updateInternalHourlyCost]
 
-Update the internal hourly cost for a single user.
+Update the internal hourly cost for a single user. Only account administrators can set the internal hourly cost of a user.
 
 + Request (application/json;charset=utf-8)
 

--- a/src/01-general/users.apib
+++ b/src/01-general/users.apib
@@ -120,3 +120,17 @@ Get details for a single user.
                     + tr-TR
             + function: `Sales` (string)
             + time_zone: `Europe/Brussels` (string)
+
+
+### users.updateInternalHourlyCost [POST /users.updateInternalHourlyCost]
+
+Update details for a single user.
+
++ Request (application/json;charset=utf-8)
+
+    + Attributes (object)
+        + id: `b5094b3f-bb7a-0391-b01b-e709773f3509` (string)
+        + internal_hourly_cost (object, nullable)
+            + value (Money)
+
++ Response 204 (application/json;charset=utf-8)

--- a/src/01-general/users.apib
+++ b/src/01-general/users.apib
@@ -130,6 +130,6 @@ Update the internal hourly cost for a single user. Only account administrators c
 
     + Attributes (object)
         + id: `b5094b3f-bb7a-0391-b01b-e709773f3509` (string)
-        + internal_hourly_cost (Money, nullable)
+        + internal_hourly_cost (Money)
 
 + Response 204 (application/json;charset=utf-8)


### PR DESCRIPTION
⚠️ DO NOT MERGE - `iinternal_hourly_cost rate` property is part of "profit on projects" feature flag, not yet publicly released.

Document new endpoint which allows specifying a users's internal rate.