### PR TITLE
Add a filter status on users.list

### DIFF
--- a/apiary.apib
+++ b/apiary.apib
@@ -589,6 +589,10 @@ Get a list of all users.
                 + telephones (array[Telephone])
                 + language: `nl` (string)
                 + function: `Sales` (string)
+                + status: `active` (enum[string])
+                    + Members
+                        + active
+                        + deactivated
 
 ### users.info [GET /users.info]
 

--- a/apiary.apib
+++ b/apiary.apib
@@ -555,10 +555,11 @@ Get a list of all users.
         + filter (object, optional)
             + ids: `cb8da52a-ce89-4bf6-8f7e-8ee6cb85e3b5`,`f8a57a6f-dd1e-41a3-b8d3-428663f1d09e` (array[string], optional)
             + term: `John` (string, optional) - Filters on first name, last name and email
-            + status: `active`, `deactivated` (enum[string], optional) - Filters on status
-                + Members
-                    + active - Filters on active users
-                    + deactivated - Filters on deactivated users
+            + status: `active`, `deactivated` (array[string], optional) - Filters on status
+                + (enum[string])
+                    + Members
+                        + active - Filters on active users
+                        + deactivated - Filters on deactivated users
         + sort (array, optional)
             + (object)
                 + field (enum[string], required)

--- a/apiary.apib
+++ b/apiary.apib
@@ -555,6 +555,10 @@ Get a list of all users.
         + filter (object, optional)
             + ids: `cb8da52a-ce89-4bf6-8f7e-8ee6cb85e3b5`,`f8a57a6f-dd1e-41a3-b8d3-428663f1d09e` (array[string], optional)
             + term: `John` (string, optional) - Filters on first name, last name and email
+            + status: `all` (enum[string], optional) - Filters on status
+                + Members
+                    + all - Filters on all active and deactivated users
+                    + deactivated - Filters only on deactivated users
         + sort (array, optional)
             + (object)
                 + field (enum[string], required)

--- a/apiary.apib
+++ b/apiary.apib
@@ -555,10 +555,10 @@ Get a list of all users.
         + filter (object, optional)
             + ids: `cb8da52a-ce89-4bf6-8f7e-8ee6cb85e3b5`,`f8a57a6f-dd1e-41a3-b8d3-428663f1d09e` (array[string], optional)
             + term: `John` (string, optional) - Filters on first name, last name and email
-            + status: `all` (enum[string], optional) - Filters on status
+            + status: `active`, `deactivated` (enum[string], optional) - Filters on status
                 + Members
-                    + all - Filters on all active and deactivated users
-                    + deactivated - Filters only on deactivated users
+                    + active - Filters on active users
+                    + deactivated - Filters on deactivated users
         + sort (array, optional)
             + (object)
                 + field (enum[string], required)

--- a/src/01-general/users.apib
+++ b/src/01-general/users.apib
@@ -51,6 +51,10 @@ Get a list of all users.
         + filter (object, optional)
             + ids: `cb8da52a-ce89-4bf6-8f7e-8ee6cb85e3b5`,`f8a57a6f-dd1e-41a3-b8d3-428663f1d09e` (array[string], optional)
             + term: `John` (string, optional) - Filters on first name, last name and email
+            + status: `all` (enum[string], optional) - Filters on status
+                + Members
+                    + all - Filters on all active and deactivated users
+                    + deactivated - Filters only on deactivated users
         + sort (array, optional)
             + (object)
                 + field (enum[string], required)

--- a/src/01-general/users.apib
+++ b/src/01-general/users.apib
@@ -51,10 +51,11 @@ Get a list of all users.
         + filter (object, optional)
             + ids: `cb8da52a-ce89-4bf6-8f7e-8ee6cb85e3b5`,`f8a57a6f-dd1e-41a3-b8d3-428663f1d09e` (array[string], optional)
             + term: `John` (string, optional) - Filters on first name, last name and email
-            + status: `active`, `deactivated` (enum[string], optional) - Filters on status
-                + Members
-                    + active - Filters on active users
-                    + deactivated - Filters on deactivated users
+            + status: `active`, `deactivated` (array[string], optional) - Filters on status
+                + (enum[string])
+                    + Members
+                        + active - Filters on active users
+                        + deactivated - Filters on deactivated users
         + sort (array, optional)
             + (object)
                 + field (enum[string], required)

--- a/src/01-general/users.apib
+++ b/src/01-general/users.apib
@@ -85,6 +85,10 @@ Get a list of all users.
                 + telephones (array[Telephone])
                 + language: `nl` (string)
                 + function: `Sales` (string)
+                + status: `active` (enum[string])
+                    + Members
+                        + active
+                        + deactivated
 
 ### users.info [GET /users.info]
 

--- a/src/01-general/users.apib
+++ b/src/01-general/users.apib
@@ -51,10 +51,10 @@ Get a list of all users.
         + filter (object, optional)
             + ids: `cb8da52a-ce89-4bf6-8f7e-8ee6cb85e3b5`,`f8a57a6f-dd1e-41a3-b8d3-428663f1d09e` (array[string], optional)
             + term: `John` (string, optional) - Filters on first name, last name and email
-            + status: `all` (enum[string], optional) - Filters on status
+            + status: `active`, `deactivated` (enum[string], optional) - Filters on status
                 + Members
-                    + all - Filters on all active and deactivated users
-                    + deactivated - Filters only on deactivated users
+                    + active - Filters on active users
+                    + deactivated - Filters on deactivated users
         + sort (array, optional)
             + (object)
                 + field (enum[string], required)


### PR DESCRIPTION
To be able to implement the inviting of users and the future of unique email addresses. We first need to be able to filter on all users to find if an email is already used or not. This will be the first step in doing so.

In a follow-up a filter `email` will be added.

Not sure yet how we would show the status in the response though.

Do we show the status as an enum:
```
{
    "status": "active|deactivated|...inactive"
}
```
Or do we show it as a boolean:
```
{
    "active": true
}
```