### PR TITLE
Allow signing WorkOrders during finalization

### DIFF
--- a/apiary.apib
+++ b/apiary.apib
@@ -3680,12 +3680,13 @@ Update a draft work order.
 
 ### workOrders.finalize [POST /workOrders.finalize]
 
-Finalize a draft work order. This will also generate the work order PDF.
+Finalize a draft work order with an optional signature. This will also generate the work order PDF.
 
 + Request (application/json;charset=utf-8)
 
     + Attributes (object)
        + id: `4afb0a9c-91c6-49ed-a2e5-ce7c1e3a87fb` (string, required)
+       + signature: `data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAABAAAAAQCAIAAACQkWg2AAAAAXNSR0IArs4c6QAAAVlpVFh0WE1MOmNvbS5hZG9iZS54bXAAAAAAADx4OnhtcG1ldGEgeG1sbnM6eD0iYWRvYmU6bnM6bWV0YS8AAAASUVORK5CYII=` (string, optional) - PNG image, base64 encoded
 
 + Response 204
 

--- a/src/09-workorders/work-orders.apib
+++ b/src/09-workorders/work-orders.apib
@@ -121,12 +121,13 @@ Update a draft work order.
 
 ### workOrders.finalize [POST /workOrders.finalize]
 
-Finalize a draft work order. This will also generate the work order PDF.
+Finalize a draft work order with an optional signature. This will also generate the work order PDF.
 
 + Request (application/json;charset=utf-8)
 
     + Attributes (object)
        + id: `4afb0a9c-91c6-49ed-a2e5-ce7c1e3a87fb` (string, required)
+       + signature: `data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAABAAAAAQCAIAAACQkWg2AAAAAXNSR0IArs4c6QAAAVlpVFh0WE1MOmNvbS5hZG9iZS54bXAAAAAAADx4OnhtcG1ldGEgeG1sbnM6eD0iYWRvYmU6bnM6bWV0YS8AAAASUVORK5CYII=` (string, optional) - PNG image, base64 encoded
 
 + Response 204
 


### PR DESCRIPTION
Since we don't want signed work orders to still change, we need to sign
during the finalization step.