### PR TITLE
Don't allow updating the meeting of a draft work order

### DIFF
--- a/apiary.apib
+++ b/apiary.apib
@@ -3676,7 +3676,6 @@ Update a draft work order.
         + description: `Pipework intervention` (string, optional, nullable)
         + department_id: `cef01135-7e51-4f6f-a6eb-6e5e5a885ac7` (string, optional, nullable)
         + milestone_id: `e94c1363-3426-46a4-921d-fce03f39bbd5` (string, optional, nullable)
-        + event_id: `9fc14045-5c6c-4ba8-8672-42ea3f26aa63` (string, optional, nullable)
         + location (Address, optional, nullable)
         + time (array, optional)
             + (object)

--- a/src/09-workorders/work-orders.apib
+++ b/src/09-workorders/work-orders.apib
@@ -117,7 +117,6 @@ Update a draft work order.
         + description: `Pipework intervention` (string, optional, nullable)
         + department_id: `cef01135-7e51-4f6f-a6eb-6e5e5a885ac7` (string, optional, nullable)
         + milestone_id: `e94c1363-3426-46a4-921d-fce03f39bbd5` (string, optional, nullable)
-        + event_id: `9fc14045-5c6c-4ba8-8672-42ea3f26aa63` (string, optional, nullable)
         + location (Address, optional, nullable)
         + time (array, optional)
             + (object)


### PR DESCRIPTION
We want to have the limitation of allowing only one draft work order on
any meeting. Not allowing to update will already make sure that we can
enforce this business rule in only one place. We might then make a
dedicated "workOrder.linkToMeeting" or "workOrder.planForMeeting"
endpoint later.