### PR TITLE
Remove charset from requests and responses

### DIFF
--- a/GUIDELINES.md
+++ b/GUIDELINES.md
@@ -79,8 +79,8 @@ We try to interpret HTTP Status codes the right way:
 
 ### Content-Type & Accept headers
 
- - `application/json` or `application/json;charset=utf-8` for request accept headers
- - `application/json;charset=utf-8` for response content-type headers
+ - `application/json` or `application/json` for request accept headers
+ - `application/json` for response content-type headers
 
 ## Response format
 

--- a/apiary.apib
+++ b/apiary.apib
@@ -215,7 +215,7 @@ These access tokens are also known as bearer tokens. You can use this token to c
 ```
 GET https://api.teamleader.eu/contacts.list HTTP/1.1
 Authorization: Bearer eyJ0eXAiOiJKV1QiLCJhbGciO...
-Accept: application/json;charset=utf-8
+Accept: application/json
 ```
 
 Access tokens expire shortly (usually 1 hour) after they are issued for security reasons. If your integration needs to communicate with our API beyond the access token's lifespan, you will need to request a new access token using the refresh token which was issued with the access token. Note that refresh tokens can only be used once to get a new access token and refresh token.
@@ -444,7 +444,7 @@ Get a list of departments.
                     + field: `name`
                     + order: `asc`
 
-+ Response 200 (application/json;charset=utf-8)
++ Response 200 (application/json)
 
     + Attributes (object)
         + data (array)
@@ -463,7 +463,7 @@ Get details for a single department.
     + Attributes (object)
         + id: `92296ad0-2d61-4179-b174-9f354ca2157f` (string, required)
 
-+ Response 200 (application/json;charset=utf-8)
++ Response 200 (application/json)
 
     + Attributes (object)
         + data  (object)
@@ -537,7 +537,7 @@ Get the current authenticated user.
 
 Get a list of all users.
 
-+ Request (application/json;charset=utf-8)
++ Request (application/json)
 
     + Attributes (object)
         + filter (object, optional)
@@ -557,7 +557,7 @@ Get a list of all users.
                     + order: `asc`
         + page (Page, optional)
 
-+ Response 200 (application/json;charset=utf-8)
++ Response 200 (application/json)
 
     + Attributes (object)
         + data (array)
@@ -621,7 +621,7 @@ Custom fields are used to add additional data/properties to entities within Team
 
 Get a list of all the definitions of custom fields.
 
-+ Request (application/json;charset=utf-8)
++ Request (application/json)
 
     + Attributes (object)
         + page (Page, optional)
@@ -640,7 +640,7 @@ Get a list of all the definitions of custom fields.
                     + field: `label`
                     + order: `asc`
 
-+ Response 200 (application/json;charset=utf-8)
++ Response 200 (application/json)
 
     + Attributes (object)
         + data (array)
@@ -687,12 +687,12 @@ Get a list of all the definitions of custom fields.
 
 Get info about a specific custom field definition.
 
-+ Request (application/json;charset=utf-8)
++ Request (application/json)
 
     + Attributes (object)
         + id: `9c64570b-4ec1-4e03-9662-af904f78f7fa` (string, required)
 
-+ Response 200 (application/json;charset=utf-8)
++ Response 200 (application/json)
 
     + Attributes (object)
         + data (object)
@@ -742,7 +742,7 @@ Work types define the type of work for events or time tracking. Hourly rates can
 
 Get a list of all work types, sorted alphabetically (on their name).
 
-+ Request (application/json;charset=utf-8)
++ Request (application/json)
 
     + Attributes (object)
         + filter (object, optional)
@@ -754,7 +754,7 @@ Get a list of all work types, sorted alphabetically (on their name).
                     + field: `name`
                     + order: `asc`
 
-+ Response 200 (application/json;charset=utf-8)
++ Response 200 (application/json)
 
     + Attributes (object)
         + data (array)
@@ -768,7 +768,7 @@ Get a list of all work types, sorted alphabetically (on their name).
 
 Get a list of all document templates.
 
-+ Request (application/json;charset=utf-8)
++ Request (application/json)
 
     + Attributes (object)
         + filter (object, optional)
@@ -783,7 +783,7 @@ Get a list of all document templates.
                     + timetracking_report
                     + workorder
 
-+ Response 200 (application/json;charset=utf-8)
++ Response 200 (application/json)
 
     + Attributes (object)
         + data (array)
@@ -815,7 +815,7 @@ Contacts are physical entities who are added to your CRM database. Contacts migh
 
 Get a list of contacts.
 
-+ Request (application/json;charset=utf-8)
++ Request (application/json)
 
     + Attributes (object)
         + filter (object, optional)
@@ -846,7 +846,7 @@ Get a list of contacts.
                     + field: `name`
                     + order: `asc`
 
-+ Response 200 (application/json;charset=utf-8)
++ Response 200 (application/json)
 
     + Attributes (object)
         + data (array)
@@ -886,12 +886,12 @@ Get a list of contacts.
 
 Get details for a single contact.
 
-+ Request (application/json;charset=utf-8)
++ Request (application/json)
 
     + Attributes (object)
         + id: `cde0bc5f-8602-4e12-b5d3-f03436b54c0d` (string, required)
 
-+ Response 200 (application/json;charset=utf-8)
++ Response 200 (application/json)
 
     + Attributes (object)
         + data (object)
@@ -948,7 +948,7 @@ Get details for a single contact.
 
 Add a new contact.
 
-+ Request (application/json;charset=utf-8)
++ Request (application/json)
 
     + Attributes (object)
         + first_name: `John` (string, optional)
@@ -986,7 +986,7 @@ Add a new contact.
         + custom_fields (array[CustomFieldValue], optional)
         + marketing_mails_consent: false (boolean, optional)
 
-+ Response 201 (application/json;charset=utf-8)
++ Response 201 (application/json)
 
     + Attributes (object)
         + data (object)
@@ -997,7 +997,7 @@ Add a new contact.
 
 Update a contact.
 
-+ Request (application/json;charset=utf-8)
++ Request (application/json)
 
     + Attributes (object)
         + id: `76c9d03c-ec5c-4b21-9fc6-7ffee488b12d` (string, required)
@@ -1042,7 +1042,7 @@ Update a contact.
 
 Delete a contact.
 
-+ Request (application/json;charset=utf-8)
++ Request (application/json)
 
     + Attributes (object)
         + id: `4e235f27-0af0-40e5-82f3-d32d0aa9edb3` (string, required)
@@ -1053,7 +1053,7 @@ Delete a contact.
 
 Add a new or existing tag to a contact.
 
-+ Request (application/json;charset=utf-8)
++ Request (application/json)
 
     + Attributes (object)
         + id: `cadd94ba-a41e-4eb4-a46e-39a7f6f96070` (string, required)
@@ -1065,7 +1065,7 @@ Add a new or existing tag to a contact.
 
 Remove a tag from a contact.
 
-+ Request (application/json;charset=utf-8)
++ Request (application/json)
 
     + Attributes (object)
         + id: `518d2e5e-99bc-4c66-8509-78e6820a1418` (string, required)
@@ -1077,7 +1077,7 @@ Remove a tag from a contact.
 
 Link a contact to a company.
 
-+ Request (application/json;charset=utf-8)
++ Request (application/json)
 
     + Attributes (object)
         + id: `75596038-b9c8-4a37-969d-61059e300a28` (string, required)
@@ -1091,7 +1091,7 @@ Link a contact to a company.
 
 Unlink a contact from a company.
 
-+ Request (application/json;charset=utf-8)
++ Request (application/json)
 
     + Attributes (object)
         + id: `b4b3160a-b55e-4033-bdae-25b6d22949b4` (string, required)
@@ -1109,7 +1109,7 @@ Companies are legal entities, usually linked to a VAT and/or local business numb
 
 Get a list of companies.
 
-+ Request (application/json;charset=utf-8)
++ Request (application/json)
 
     + Attributes (object)
         + filter (object, optional)
@@ -1139,7 +1139,7 @@ Get a list of companies.
                     + field: `name`
                     + order: `asc`
 
-+ Response 200 (application/json;charset=utf-8)
++ Response 200 (application/json)
 
     + Attributes (object)
         + data (array)
@@ -1180,12 +1180,12 @@ Get a list of companies.
 
 Get details for a single company.
 
-+ Request (application/json;charset=utf-8)
++ Request (application/json)
 
     + Attributes (object)
         + id: `e8d31ae7-8258-4fcd-9b2d-78f41b0aa5d5` (string, required)
 
-+ Response 200 (application/json;charset=utf-8)
++ Response 200 (application/json)
 
     + Attributes (object)
         + data (object)
@@ -1236,7 +1236,7 @@ Get details for a single company.
 
 Add a new company.
 
-+ Request (application/json;charset=utf-8)
++ Request (application/json)
 
     + Attributes (object)
         + name: `Pied Piper` (string, required)
@@ -1270,7 +1270,7 @@ Add a new company.
         + custom_fields (array[CustomFieldValue], optional)
         + marketing_mails_consent: false (boolean, optional)
 
-+ Response 201 (application/json;charset=utf-8)
++ Response 201 (application/json)
 
     + Attributes (object)
         + data (object)
@@ -1281,7 +1281,7 @@ Add a new company.
 
 Update a company.
 
-+ Request (application/json;charset=utf-8)
++ Request (application/json)
 
     + Attributes (object)
         + id: `4784189d-610b-4488-b3a5-5f324f752417` (string, required)
@@ -1321,7 +1321,7 @@ Update a company.
 
 Delete a company.
 
-+ Request (application/json;charset=utf-8)
++ Request (application/json)
 
     + Attributes (object)
         + id: `f3d67f3e-b8a9-45e8-99b1-17a3b14de8a6` (string, required)
@@ -1332,7 +1332,7 @@ Delete a company.
 
 Add a new or existing tag to a company.
 
-+ Request (application/json;charset=utf-8)
++ Request (application/json)
 
     + Attributes (object)
         + id: `cadd94ba-a41e-4eb4-a46e-39a7f6f96070` (string, required)
@@ -1344,7 +1344,7 @@ Add a new or existing tag to a company.
 
 Remove a tag from a company.
 
-+ Request (application/json;charset=utf-8)
++ Request (application/json)
 
     + Attributes (object)
         + id: `518d2e5e-99bc-4c66-8509-78e6820a1418` (string, required)
@@ -1360,12 +1360,12 @@ Each country has a specific set of business types or range of legal entities. Yo
 
 Get the names of business types (legal structures) a company can have within a certain country, sorted alphabetically.
 
-+ Request (application/json;charset=utf-8)
++ Request (application/json)
 
     + Attributes (object)
         + country: `BE` (string, optional)
 
-+ Response 200 (application/json;charset=utf-8)
++ Response 200 (application/json)
 
     + Attributes (object)
         + data (array[object])
@@ -1381,7 +1381,7 @@ Tags are used to label contacts or companies, so that they can easily be filtere
 
 Get a list of tags.
 
-+ Request (application/json;charset=utf-8)
++ Request (application/json)
 
     + Attributes (object)
         + page (Page, optional)
@@ -1398,7 +1398,7 @@ Get a list of tags.
                     + field: `tag`
                     + order: `asc`
 
-+ Response 200 (application/json;charset=utf-8)
++ Response 200 (application/json)
 
     + Attributes (object)
         + data (array)
@@ -1413,13 +1413,13 @@ We provide a set of data which can be used to build addresses.
 
 Get a list of level two areas (which correspond to provinces, departments or states in most countries).
 
-+ Request (application/json;charset=utf-8)
++ Request (application/json)
 
     + Attributes (object)
         + country: `BE` (string, required)
         + language: `nl` (string, optional) - if not passed, the name is returned in the primary language of the country
 
-+ Response 200 (application/json;charset=utf-8)
++ Response 200 (application/json)
 
     + Attributes (object)
         + data (array[object])
@@ -1439,7 +1439,7 @@ Deals are sale opportunities, which need to be followed up by their responsible 
 
 Get a list of deals.
 
-+ Request (application/json;charset=utf-8)
++ Request (application/json)
 
     + Attributes (object)
         + filter (object, optional)
@@ -1469,7 +1469,7 @@ Get a list of deals.
                     + order: `desc`
 
 
-+ Response 200 (application/json;charset=utf-8)
++ Response 200 (application/json)
 
     + Attributes (object)
         + data (array)
@@ -1517,12 +1517,12 @@ Get a list of deals.
 
 Get details for a single deal.
 
-+ Request (application/json;charset=utf-8)
++ Request (application/json)
 
     + Attributes (object)
         + id: `f6871b06-6513-4750-b5e6-ff3503b5a029` (string, required)
 
-+ Response 200 (application/json;charset=utf-8)
++ Response 200 (application/json)
 
     + Attributes (object)
         + data (object)
@@ -1582,7 +1582,7 @@ Get details for a single deal.
 
 Create a new deal for a customer.
 
-+ Request (application/json;charset=utf-8)
++ Request (application/json)
 
     + Attributes (object)
         + lead (object, required)
@@ -1603,7 +1603,7 @@ Create a new deal for a customer.
         + estimated_closing_date: `2017-05-09` (string, optional)
         + custom_fields (array[CustomFieldValue], optional)
 
-+ Response 201 (application/json;charset=utf-8)
++ Response 201 (application/json)
 
     + Attributes (object)
         + data (object)
@@ -1614,7 +1614,7 @@ Create a new deal for a customer.
 
 Update a deal.
 
-+ Request (application/json;charset=utf-8)
++ Request (application/json)
 
     + Attributes (object)
         + id: `65a35860-dcca-4850-9fd6-47ff08469e0c` (string, required)
@@ -1641,7 +1641,7 @@ Update a deal.
 
 Move the deal to a different phase.
 
-+ Request (application/json;charset=utf-8)
++ Request (application/json)
 
     + Attributes (object)
         + id: `e88131bf-50c4-49d3-8ae3-47e5d9626bf6` (string, required)
@@ -1653,7 +1653,7 @@ Move the deal to a different phase.
 
 Mark a deal as won.
 
-+ Request (application/json;charset=utf-8)
++ Request (application/json)
 
     + Attributes (object)
         + id: `e88131bf-50c4-49d3-8ae3-47e5d9626bf6` (string, required)
@@ -1664,7 +1664,7 @@ Mark a deal as won.
 
 Mark a deal as lost.
 
-+ Request (application/json;charset=utf-8)
++ Request (application/json)
 
     + Attributes (object)
         + id: `460df7b2-fe82-4c6c-b215-6d0a1bd3c742` (string, required)
@@ -1677,7 +1677,7 @@ Mark a deal as lost.
 
 Delete a deal.
 
-+ Request (application/json;charset=utf-8)
++ Request (application/json)
 
     + Attributes (object)
         + id: `4e235f27-0af0-40e5-82f3-d32d0aa9edb3` (string, required)
@@ -1688,7 +1688,7 @@ Delete a deal.
 
 Get a list of lost reasons for deals.
 
-+ Request (application/json;charset=utf-8)
++ Request (application/json)
 
     + Attributes (object)
         + page (Page, optional)
@@ -1705,7 +1705,7 @@ Get a list of lost reasons for deals.
                     + field: `name`
                     + order: `asc`
 
-+ Response 200 (application/json;charset=utf-8)
++ Response 200 (application/json)
 
     + Attributes (object)
         + data (array)
@@ -1723,14 +1723,14 @@ Deal phases are the different phases a deal typically goes through. A deal can b
 
 Get a list of all phases a deal can go through, sorted by their order in the flow.
 
-+ Request (application/json;charset=utf-8)
++ Request (application/json)
 
     + Attributes (object)
         + filter (object, optional)
             + ids: `53a7e592-a136-4bae-ae15-517befd3d75d`,`bb50af79-55cd-4be0-8306-e9626c70a90f` (array[string], optional)
         + page (Page, optional)
 
-+ Response 200 (application/json;charset=utf-8)
++ Response 200 (application/json)
 
     + Attributes (object)
         + data (array)
@@ -1748,7 +1748,7 @@ Deal sources are used to track the origin of a deal.
 
 Get a list of all deal sources, sorted alphabetically (on name)
 
-+ Request (application/json;charset=utf-8)
++ Request (application/json)
 
     + Attributes (object)
         + filter (object, optional)
@@ -1760,7 +1760,7 @@ Get a list of all deal sources, sorted alphabetically (on name)
                     + field: `name`
                     + order: `asc`
 
-+ Response 200 (application/json;charset=utf-8)
++ Response 200 (application/json)
 
     + Attributes (object)
         + data (array)
@@ -1778,12 +1778,12 @@ A quotation is a sales offer for a specific customer. It is always attached to a
 
 Get a quotation
 
-+ Request (application/json;charset=utf-8)
++ Request (application/json)
 
     + Attributes (object)
         + id: `e7a3fe2b-2c75-480f-87b9-121816b5257b` (string, required)
 
-+ Response 200 (application/json;charset=utf-8)
++ Response 200 (application/json)
 
     + Attributes (object)
         + data (object)
@@ -1825,7 +1825,7 @@ Get a quotation
 
 Download a quotation in a specific format.
 
-+ Request (application/json;charset=utf-8)
++ Request (application/json)
 
     + Attributes (object)
         + id: `d885e5d5-bacb-4607-bde9-abc4a04a901b` (string, required)
@@ -1833,7 +1833,7 @@ Download a quotation in a specific format.
             + Members
                 + pdf
 
-+ Response 200 (application/json;charset=utf-8)
++ Response 200 (application/json)
 
     + Attributes (object)
         + data (object)
@@ -1852,7 +1852,7 @@ Calendar events are scheduled events in your calendar. A calendar event involves
 
 Get a list of calendar events.
 
-+ Request (application/json;charset=utf-8)
++ Request (application/json)
 
     + Attributes (object)
         + filter (object, optional)
@@ -1887,7 +1887,7 @@ Get a list of calendar events.
                     + field: starts_at
                     + order: asc
 
-+ Response 200 (application/json;charset=utf-8)
++ Response 200 (application/json)
 
     + Attributes (object)
         + data (array)
@@ -1927,12 +1927,12 @@ Get a list of calendar events.
 
 Get details for a single calendar event.
 
-+ Request (application/json;charset=utf-8)
++ Request (application/json)
 
     + Attributes (object)
         + id: `9a5a3984-abfc-40cd-a880-f97683c6a99c` (string, required)
 
-+ Response 200 (application/json;charset=utf-8)
++ Response 200 (application/json)
 
     + Attributes (object)
         + data (object)
@@ -1970,7 +1970,7 @@ Get details for a single calendar event.
 
 Create a new calendar event.
 
-+ Request (application/json;charset=utf-8)
++ Request (application/json)
 
     + Attributes
         + title: `Meeting with stakeholders` (string, required)
@@ -1995,7 +1995,7 @@ Create a new calendar event.
                         + contact
                 + id: `c9258836-f9a5-40cb-aa2a-d55c22991b93` (string, required)
 
-+ Response 201 (application/json;charset=utf-8)
++ Response 201 (application/json)
 
     + Attributes (object)
         + data (object)
@@ -2006,7 +2006,7 @@ Create a new calendar event.
 
 Update a calendar event.
 
-+ Request (application/json;charset=utf-8)
++ Request (application/json)
 
     + Attributes
         + id: `f22fc69d-5d07-40cf-af46-015698a74b63` (string, required)
@@ -2037,7 +2037,7 @@ Update a calendar event.
 
 Cancel a calendar event (for all attendees).
 
-+ Request (application/json;charset=utf-8)
++ Request (application/json)
 
     + Attributes (object)
         + id: `b519491e-ca80-4efb-bb7b-3f08544936b0` (string, required)
@@ -2052,14 +2052,14 @@ Activity types identify the different types of events that take place within you
 
 Get a list of all activity types.
 
-+ Request (application/json;charset=utf-8)
++ Request (application/json)
 
     + Attributes (object)
         + filter (object, optional)
             + ids: `7fcf5609-25fe-47e2-97b2-dbd9c817796e`,`366b6100-7005-4b1b-a16a-7e88f445f496` (array[string], optional)
         + page (Page, optional)
 
-+ Response 200 (application/json;charset=utf-8)
++ Response 200 (application/json)
 
     + Attributes (object)
         + data (array)
@@ -2079,7 +2079,7 @@ Teamleader provides a whole set of endpoints to make it easy to develop integrat
 
 Get a list of invoices.
 
-+ Request (application/json;charset=utf-8)
++ Request (application/json)
 
     + Attributes (object)
         + filter (object, optional)
@@ -2104,7 +2104,7 @@ Get a list of invoices.
                     + field: `invoice_number`
                     + order: `asc`
 
-+ Response 200 (application/json;charset=utf-8)
++ Response 200 (application/json)
 
     + Attributes (object)
         + data (array)
@@ -2150,12 +2150,12 @@ Get a list of invoices.
 
 Get details for a single invoice.
 
-+ Request (application/json;charset=utf-8)
++ Request (application/json)
 
     + Attributes (object)
         + id: `27300f09-6250-4a23-8557-d84c52f99ecf` (string)
 
-+ Response 200 (application/json;charset=utf-8)
++ Response 200 (application/json)
 
     + Attributes (object)
         + data (object)
@@ -2265,7 +2265,7 @@ Get details for a single invoice.
 
 Download an invoice in a specific format.
 
-+ Request (application/json;charset=utf-8)
++ Request (application/json)
 
     + Attributes (object)
         + id: `d885e5d5-bacb-4607-bde9-abc4a04a901b` (string, required)
@@ -2273,7 +2273,7 @@ Download an invoice in a specific format.
             + Members
                 + pdf
 
-+ Response 200 (application/json;charset=utf-8)
++ Response 200 (application/json)
 
     + Attributes (object)
         + data (object)
@@ -2284,7 +2284,7 @@ Download an invoice in a specific format.
 
 Draft a new invoice.
 
-+ Request (application/json;charset=utf-8)
++ Request (application/json)
 
     + Attributes (object)
         + invoicee (object, required)
@@ -2333,7 +2333,7 @@ Draft a new invoice.
         + note: `Invoice comments` (string, optional)
         + custom_fields (array[CustomFieldValue], optional)
 
-+ Response 201 (application/json;charset=utf-8)
++ Response 201 (application/json)
 
     + Attributes (object)
         + data (object)
@@ -2344,7 +2344,7 @@ Draft a new invoice.
 
 Update an invoice.
 
-+ Request (application/json;charset=utf-8)
++ Request (application/json)
 
     + Attributes (object)
         + id: `b7023c11-455e-4fa5-bb96-87f37dbc7d07` (string, required)
@@ -2399,12 +2399,12 @@ Update an invoice.
 
 Creates a new draft invoice based on another invoice
 
-+ Request (application/json;charset=utf-8)
++ Request (application/json)
 
     + Attributes (object)
         + id: `b7023c11-455e-4fa5-bb96-87f37dbc7d07` (string, required)
 
-+ Response 201 (application/json;charset=utf-8)
++ Response 201 (application/json)
 
     + Attributes (object)
         + data (object)
@@ -2415,7 +2415,7 @@ Creates a new draft invoice based on another invoice
 
 Book a draft invoice.
 
-+ Request (application/json;charset=utf-8)
++ Request (application/json)
 
     + Attributes (object)
         + id: `7abb325c-e063-42a4-8fb4-1b730759645a` (string, required)
@@ -2427,7 +2427,7 @@ Book a draft invoice.
 
 Delete an existing invoice. Only possible for draft invoices or the last booked invoice.
 
-+ Request (application/json;charset=utf-8)
++ Request (application/json)
 
     + Attributes (object)
         + id: `7517d21c-75c1-4b89-8956-0e67f46c8532` (string, required)
@@ -2438,7 +2438,7 @@ Delete an existing invoice. Only possible for draft invoices or the last booked 
 
 Register a payment for an invoice.
 
-+ Request (application/json;charset=utf-8)
++ Request (application/json)
 
     + Attributes (object)
         + id: `7abb325c-e063-42a4-8fb4-1b730759645a` (string, required)
@@ -2458,7 +2458,7 @@ Credit notes are created when certain products or services are not delivered acc
 
 List credit notes
 
-+ Request (application/json;charset=utf-8)
++ Request (application/json)
 
     + Attributes (object)
         + filter (object, optional)
@@ -2478,7 +2478,7 @@ List credit notes
                     + field: `credit_note_number`
                     + order: `asc`
 
-+ Response 200 (application/json;charset=utf-8)
++ Response 200 (application/json)
 
     + Attributes (object)
         + data (array)
@@ -2519,12 +2519,12 @@ List credit notes
 
 Get details for a single credit note
 
-+ Request (application/json;charset=utf-8)
++ Request (application/json)
 
     + Attributes (object)
         + id: `27300f09-6250-4a23-8557-d84c52f99ecf` (string, required)
 
-+ Response 200 (application/json;charset=utf-8)
++ Response 200 (application/json)
 
     + Attributes (object)
         + data (array)
@@ -2603,7 +2603,7 @@ Get details for a single credit note
 
 Download a credit note in a specific format.
 
-+ Request (application/json;charset=utf-8)
++ Request (application/json)
 
     + Attributes (object)
         + id: `d885e5d5-bacb-4607-bde9-abc4a04a901b` (string, required)
@@ -2611,7 +2611,7 @@ Download a credit note in a specific format.
             + Members
                 + pdf
 
-+ Response 200 (application/json;charset=utf-8)
++ Response 200 (application/json)
 
     + Attributes (object)
         + data (object)
@@ -2626,7 +2626,7 @@ Tax rates provide an overview of different taxation rates used to bill customers
 
 Get a list of available tax rates.
 
-+ Request (application/json;charset=utf-8)
++ Request (application/json)
 
 + Attributes (object)
     + filter (object, optional)
@@ -2645,7 +2645,7 @@ Get a list of available tax rates.
                     + field: `description`
                     + order: `asc`
 
-+ Response 200 (application/json;charset=utf-8)
++ Response 200 (application/json)
 
     + Attributes (object)
         + data (array)
@@ -2665,9 +2665,9 @@ Payment terms are the conditions under which an invoice need to be paid.
 
 Get a list of available payment terms.
 
-+ Request (application/json;charset=utf-8)
++ Request (application/json)
 
-+ Response 200 (application/json;charset=utf-8)
++ Response 200 (application/json)
 
     + Attributes (object)
         + data (array)
@@ -2683,13 +2683,13 @@ Withholding tax rates provide an overview of different taxation rates used to bi
 
 Get a list of available withholding tax rates.
 
-+ Request (application/json;charset=utf-8)
++ Request (application/json)
 
 + Attributes (object)
     + filter (object, optional)
         + department_id: `080aac72-ff1a-4627-bfe3-146b6eee979c` (string, optional) - The ID of the department you wish to filter on.
 
-+ Response 200 (application/json;charset=utf-8)
++ Response 200 (application/json)
 
     + Attributes (object)
         + data (array)
@@ -2713,13 +2713,13 @@ Product categories are used to group specific products. They can be linked to a 
 
 Get a list of product categories.
 
-+ Request (application/json;charset=utf-8)
++ Request (application/json)
 
     + Attributes (object)
         + filter (object, optional)
             + department_id: `080aac72-ff1a-4627-bfe3-146b6eee979c` (string, optional) - The ID of the department you wish to filter on.
 
-+ Response 200 (application/json;charset=utf-8)
++ Response 200 (application/json)
 
     + Attributes (object)
         + data (array)
@@ -2741,14 +2741,14 @@ Get a list of product categories.
 
 Get a list of products.
 
-+ Request (application/json;charset=utf-8)
++ Request (application/json)
 
     + Attributes (object)
         + filter (object, optional)
             + ids: `bbbfe0da-e692-4ee3-9d3d-0716808d6523`,`722e1eb9-53d5-4b8c-9d17-154dcc65c610` (array[string], optional)
             + term: `cookies` (string, optional) - The name and the external id.
 
-+ Response 200 (application/json;charset=utf-8)
++ Response 200 (application/json)
 
     + Attributes (object)
         + data (array)
@@ -2772,7 +2772,7 @@ Projects allow users to work together as a team on a single project. They consis
 
 Get a list of projects.
 
-+ Request (application/json;charset=utf-8)
++ Request (application/json)
 
     + Attributes (object)
         + filter (object, optional)
@@ -2804,7 +2804,7 @@ Get a list of projects.
                     + field: `due_on`
                     + order: `asc`
 
-+ Response 200 (application/json;charset=utf-8)
++ Response 200 (application/json)
 
     + Attributes (object)
         + data (array)
@@ -2833,12 +2833,12 @@ Get a list of projects.
 
 Get details for a single project.
 
-+ Request (application/json;charset=utf-8)
++ Request (application/json)
 
     + Attributes (object)
         + id: `8a04371b-2ffb-407b-9b24-d5b5452009c7` (string, required)
 
-+ Response 200 (application/json;charset=utf-8)
++ Response 200 (application/json)
 
     + Attributes (object)
         + data (object)
@@ -2884,7 +2884,7 @@ Get details for a single project.
 
 Create a new project.
 
-+ Request (application/json;charset=utf-8)
++ Request (application/json)
 
     + Attributes (object)
         + title: `New company website` (string, required)
@@ -2912,7 +2912,7 @@ Create a new project.
                     + company
             + id: `ebafa4c5-fa8a-4409-92e5-1b192243372f` (string, required)
 
-+ Response 201 (application/json;charset=utf-8)
++ Response 201 (application/json)
 
     + Attributes (object)
         + data (object)
@@ -2924,7 +2924,7 @@ Create a new project.
 
 Update a project.
 
-+ Request (application/json;charset=utf-8)
++ Request (application/json)
 
     + Attributes (object)
         + id: `dcc2e8ed-51be-4cb6-9c01-034aedac86fd` (string, required)
@@ -2938,26 +2938,26 @@ Update a project.
                 + cancelled
         + starts_on: `2016-02-04` (string, required)
 
-+ Response 204 (application/json;charset=utf-8)
++ Response 204 (application/json)
 
 
 ### projects.delete [POST /projects.delete]
 
 Delete a project.
 
-+ Request (application/json;charset=utf-8)
++ Request (application/json)
 
     + Attributes (object)
         + id: `01548b10-4932-4a18-8a89-005ad09db2c8` (string, required)
 
-+ Response 204 (application/json;charset=utf-8)
++ Response 204 (application/json)
 
 
 ### projects.addParticipant [POST /projects.addParticipant]
 
 Add a participant to a project.
 
-+ Request (application/json;charset=utf-8)
++ Request (application/json)
 
     + Attributes (object)
         + id: `8dbfa9db-c53f-410c-97d3-755b19685809` (string, required)
@@ -2977,7 +2977,7 @@ Add a participant to a project.
 
 Update a participant's role for a project.
 
-+ Request (application/json;charset=utf-8)
++ Request (application/json)
 
     + Attributes (object)
         + id: `55fbe14f-7399-48e5-b4e0-64b7f5c50451` (string, required)
@@ -3001,7 +3001,7 @@ Every projects consists of one or more milestones which are limited in time and 
 
 Get a list of project milestones.
 
-+ Request (application/json;charset=utf-8)
++ Request (application/json)
 
     + Attributes (object)
         + filter (object, optional)
@@ -3027,7 +3027,7 @@ Get a list of project milestones.
                     + field: `due_on`
                     + order: `asc`
 
-+ Response 200 (application/json;charset=utf-8)
++ Response 200 (application/json)
 
     + Attributes (object)
         + data (array)
@@ -3055,12 +3055,12 @@ Get a list of project milestones.
 
 Get details for a single milestone.
 
-+ Request (application/json;charset=utf-8)
++ Request (application/json)
 
     + Attributes (object)
         + id: `64349fa2-6ca2-4b19-82e6-d3258ceab2d8` (string, required)
 
-+ Response 200 (application/json;charset=utf-8)
++ Response 200 (application/json)
 
     + Attributes (object)
         + data (object)
@@ -3082,7 +3082,7 @@ Get details for a single milestone.
 
 Create a new milestone.
 
-+ Request (application/json;charset=utf-8)
++ Request (application/json)
 
     + Attributes (object)
         + project_id: `1c159f98-4b07-438a-9f42-fb4206b9530d` (string, required)
@@ -3090,7 +3090,7 @@ Create a new milestone.
         + name: `Initial setup` (string, required)
         + responsible_user_id: `e1240972-6cfc-4549-b49c-edda7568cc48` (string, required)
 
-+ Response 201 (application/json;charset=utf-8)
++ Response 201 (application/json)
 
     + Attributes (object)
         + data (object)
@@ -3101,7 +3101,7 @@ Create a new milestone.
 
 Update a milestone.
 
-+ Request (application/json;charset=utf-8)
++ Request (application/json)
 
     + Attributes (object)
         + id: `67e80ad8-d14f-4510-a2bd-a4c6aa578c37` (string, required)
@@ -3109,7 +3109,7 @@ Update a milestone.
         + name: `Initial setup` (string, optional)
         + responsible_user_id: `e1240972-6cfc-4549-b49c-edda7568cc48` (string, optional)
 
-+ Response 204 (application/json;charset=utf-8)
++ Response 204 (application/json)
 
 # Group Tasks
 
@@ -3119,7 +3119,7 @@ Update a milestone.
 
 Get a list of tasks.
 
-+ Request (application/json;charset=utf-8)
++ Request (application/json)
 
     + Attributes (object)
         + filter (object, optional)
@@ -3139,7 +3139,7 @@ Get a list of tasks.
                     + field: `due_at`
                     + order: `asc`
 
-+ Response 200 (application/json;charset=utf-8)
++ Response 200 (application/json)
 
     + Attributes (object)
         + data (array)
@@ -3168,12 +3168,12 @@ Get a list of tasks.
 
 Get information about a task.
 
-+ Request (application/json;charset=utf-8)
++ Request (application/json)
 
     + Attributes (object)
         + id: `6fac0bf0-e803-424e-af67-76863a3d7d16` (string, required)
 
-+ Response 200 (application/json;charset=utf-8)
++ Response 200 (application/json)
 
     + Attributes (object)
         + data (object)
@@ -3201,7 +3201,7 @@ Get information about a task.
 
 Create a new task.
 
-+ Request (application/json;charset=utf-8)
++ Request (application/json)
 
     + Attributes (object)
         + description (string, required)
@@ -3219,7 +3219,7 @@ Create a new task.
                     + team
             + id: `f29abf48-337d-44b4-aad4-585f5277a456` (string)
 
-+ Response 201 (application/json;charset=utf-8)
++ Response 201 (application/json)
 
     + Attributes (object)
         + data (object)
@@ -3230,7 +3230,7 @@ Create a new task.
 
 Update a task.
 
-+ Request (application/json;charset=utf-8)
++ Request (application/json)
 
     + Attributes (object)
         + id: `00ed6266-a5bd-4aac-a292-2582017b6400` (string, required)
@@ -3255,7 +3255,7 @@ Update a task.
 
 Delete a task.
 
-+ Request (application/json;charset=utf-8)
++ Request (application/json)
 
     + Attributes (object)
         + id: `5f0afd8a-8a40-48a4-bbe6-7d0e9c61bb6d` (string, required)
@@ -3563,12 +3563,12 @@ Update the current timer. Only possible if there is a timer running.
 
 Get details for a single work order.
 
-+ Request (application/json;charset=utf-8)
++ Request (application/json)
 
     + Attributes (object)
         + id: `cde0bc5f-8602-4e12-b5d3-f03436b54c0d` (string, required)
 
-+ Response 200 (application/json;charset=utf-8)
++ Response 200 (application/json)
 
     + Attributes (object)
         + data (object)
@@ -3617,7 +3617,7 @@ Get details for a single work order.
 
 Add a draft work order.
 
-+ Request (application/json;charset=utf-8)
++ Request (application/json)
 
     + Attributes (object)
        + customer (object, required)
@@ -3643,7 +3643,7 @@ Add a draft work order.
                + product_id: `e2314517-3cab-4aa9-8471-450e73449040` (string, required)
                + quantity: 3 (number, required)
 
-+ Response 201 (application/json;charset=utf-8)
++ Response 201 (application/json)
 
     + Attributes (object)
         + data (object)
@@ -3654,7 +3654,7 @@ Add a draft work order.
 
 Update a draft work order.
 
-+ Request (application/json;charset=utf-8)
++ Request (application/json)
 
     + Attributes (object)
         + id: `4afb0a9c-91c6-49ed-a2e5-ce7c1e3a87fb` (string, required)
@@ -3677,7 +3677,7 @@ Update a draft work order.
 
 Finalize a draft work order. This will also generate the work order PDF.
 
-+ Request (application/json;charset=utf-8)
++ Request (application/json)
 
     + Attributes (object)
        + id: `4afb0a9c-91c6-49ed-a2e5-ce7c1e3a87fb` (string, required)
@@ -3688,7 +3688,7 @@ Finalize a draft work order. This will also generate the work order PDF.
 
 Send a finalized work order to the customer.
 
-+ Request (application/json;charset=utf-8)
++ Request (application/json)
 
     + Attributes (object)
         + id: `4afb0a9c-91c6-49ed-a2e5-ce7c1e3a87fb` (string, required)
@@ -3706,7 +3706,7 @@ Their only use is to allow older integrations to migrate their data to the new A
 
 Translates an ID from the deprecated API into a new UUID.
 
-+ Request (application/json;charset=utf-8)
++ Request (application/json)
 
     + Attributes (object)
         + type: `contact` (enum[string])
@@ -3758,7 +3758,7 @@ Translates an ID from the deprecated API into a new UUID.
 
 Translates tax rates from the deprecated API into a new UUID tax rate.
 
-+ Request (application/json;charset=utf-8)
++ Request (application/json)
 
     + Attributes (object)
         + department_id: `6ad54ec6-ee2d-4500-afe6-0917c1aa7a38` (string)
@@ -3775,7 +3775,7 @@ Translates tax rates from the deprecated API into a new UUID tax rate.
 
 Translates "meeting", "call" and "task" into their respective activity type UUID.
 
-+ Request (application/json;charset=utf-8)
++ Request (application/json)
 
     + Attributes (object)
         + type: `meeting` (enum[string])
@@ -3797,7 +3797,7 @@ Translates "meeting", "call" and "task" into their respective activity type UUID
 
 Register a new webhook.
 
-+ Request (application/json;charset=utf-8)
++ Request (application/json)
 
     + Attributes (WebHook)
 
@@ -3807,9 +3807,9 @@ Register a new webhook.
 
 List registered webhooks ordered by URL.
 
-+ Request (application/json;charset=utf-8)
++ Request (application/json)
 
-+ Response 200 (application/json;charset=utf-8)
++ Response 200 (application/json)
 
     + Attributes (object)
         + data (array[WebHook])
@@ -3818,7 +3818,7 @@ List registered webhooks ordered by URL.
 
 Unregister a webhook.
 
-+ Request (application/json;charset=utf-8)
++ Request (application/json)
 
     + Attributes (WebHook)
 

--- a/src/01-general/custom-fields.apib
+++ b/src/01-general/custom-fields.apib
@@ -6,7 +6,7 @@ Custom fields are used to add additional data/properties to entities within Team
 
 Get a list of all the definitions of custom fields.
 
-+ Request (application/json;charset=utf-8)
++ Request (application/json)
 
     + Attributes (object)
         + page (Page, optional)
@@ -25,7 +25,7 @@ Get a list of all the definitions of custom fields.
                     + field: `label`
                     + order: `asc`
 
-+ Response 200 (application/json;charset=utf-8)
++ Response 200 (application/json)
 
     + Attributes (object)
         + data (array)
@@ -72,12 +72,12 @@ Get a list of all the definitions of custom fields.
 
 Get info about a specific custom field definition.
 
-+ Request (application/json;charset=utf-8)
++ Request (application/json)
 
     + Attributes (object)
         + id: `9c64570b-4ec1-4e03-9662-af904f78f7fa` (string, required)
 
-+ Response 200 (application/json;charset=utf-8)
++ Response 200 (application/json)
 
     + Attributes (object)
         + data (object)

--- a/src/01-general/departments.apib
+++ b/src/01-general/departments.apib
@@ -26,7 +26,7 @@ Get a list of departments.
                     + field: `name`
                     + order: `asc`
 
-+ Response 200 (application/json;charset=utf-8)
++ Response 200 (application/json)
 
     + Attributes (object)
         + data (array)
@@ -45,7 +45,7 @@ Get details for a single department.
     + Attributes (object)
         + id: `92296ad0-2d61-4179-b174-9f354ca2157f` (string, required)
 
-+ Response 200 (application/json;charset=utf-8)
++ Response 200 (application/json)
 
     + Attributes (object)
         + data  (object)

--- a/src/01-general/document-templates.apib
+++ b/src/01-general/document-templates.apib
@@ -4,7 +4,7 @@
 
 Get a list of all document templates.
 
-+ Request (application/json;charset=utf-8)
++ Request (application/json)
 
     + Attributes (object)
         + filter (object, optional)
@@ -19,7 +19,7 @@ Get a list of all document templates.
                     + timetracking_report
                     + workorder
 
-+ Response 200 (application/json;charset=utf-8)
++ Response 200 (application/json)
 
     + Attributes (object)
         + data (array)

--- a/src/01-general/users.apib
+++ b/src/01-general/users.apib
@@ -45,7 +45,7 @@ Get the current authenticated user.
 
 Get a list of all users.
 
-+ Request (application/json;charset=utf-8)
++ Request (application/json)
 
     + Attributes (object)
         + filter (object, optional)
@@ -65,7 +65,7 @@ Get a list of all users.
                     + order: `asc`
         + page (Page, optional)
 
-+ Response 200 (application/json;charset=utf-8)
++ Response 200 (application/json)
 
     + Attributes (object)
         + data (array)

--- a/src/01-general/work-types.apib
+++ b/src/01-general/work-types.apib
@@ -6,7 +6,7 @@ Work types define the type of work for events or time tracking. Hourly rates can
 
 Get a list of all work types, sorted alphabetically (on their name).
 
-+ Request (application/json;charset=utf-8)
++ Request (application/json)
 
     + Attributes (object)
         + filter (object, optional)
@@ -18,7 +18,7 @@ Get a list of all work types, sorted alphabetically (on their name).
                     + field: `name`
                     + order: `asc`
 
-+ Response 200 (application/json;charset=utf-8)
++ Response 200 (application/json)
 
     + Attributes (object)
         + data (array)

--- a/src/02-crm/addresses.apib
+++ b/src/02-crm/addresses.apib
@@ -6,13 +6,13 @@ We provide a set of data which can be used to build addresses.
 
 Get a list of level two areas (which correspond to provinces, departments or states in most countries).
 
-+ Request (application/json;charset=utf-8)
++ Request (application/json)
 
     + Attributes (object)
         + country: `BE` (string, required)
         + language: `nl` (string, optional) - if not passed, the name is returned in the primary language of the country
 
-+ Response 200 (application/json;charset=utf-8)
++ Response 200 (application/json)
 
     + Attributes (object)
         + data (array[object])

--- a/src/02-crm/business-types.apib
+++ b/src/02-crm/business-types.apib
@@ -6,12 +6,12 @@ Each country has a specific set of business types or range of legal entities. Yo
 
 Get the names of business types (legal structures) a company can have within a certain country, sorted alphabetically.
 
-+ Request (application/json;charset=utf-8)
++ Request (application/json)
 
     + Attributes (object)
         + country: `BE` (string, optional)
 
-+ Response 200 (application/json;charset=utf-8)
++ Response 200 (application/json)
 
     + Attributes (object)
         + data (array[object])

--- a/src/02-crm/companies.apib
+++ b/src/02-crm/companies.apib
@@ -8,7 +8,7 @@ Companies are legal entities, usually linked to a VAT and/or local business numb
 
 Get a list of companies.
 
-+ Request (application/json;charset=utf-8)
++ Request (application/json)
 
     + Attributes (object)
         + filter (object, optional)
@@ -38,7 +38,7 @@ Get a list of companies.
                     + field: `name`
                     + order: `asc`
 
-+ Response 200 (application/json;charset=utf-8)
++ Response 200 (application/json)
 
     + Attributes (object)
         + data (array)
@@ -79,12 +79,12 @@ Get a list of companies.
 
 Get details for a single company.
 
-+ Request (application/json;charset=utf-8)
++ Request (application/json)
 
     + Attributes (object)
         + id: `e8d31ae7-8258-4fcd-9b2d-78f41b0aa5d5` (string, required)
 
-+ Response 200 (application/json;charset=utf-8)
++ Response 200 (application/json)
 
     + Attributes (object)
         + data (object)
@@ -135,7 +135,7 @@ Get details for a single company.
 
 Add a new company.
 
-+ Request (application/json;charset=utf-8)
++ Request (application/json)
 
     + Attributes (object)
         + name: `Pied Piper` (string, required)
@@ -169,7 +169,7 @@ Add a new company.
         + custom_fields (array[CustomFieldValue], optional)
         + marketing_mails_consent: false (boolean, optional)
 
-+ Response 201 (application/json;charset=utf-8)
++ Response 201 (application/json)
 
     + Attributes (object)
         + data (object)
@@ -180,7 +180,7 @@ Add a new company.
 
 Update a company.
 
-+ Request (application/json;charset=utf-8)
++ Request (application/json)
 
     + Attributes (object)
         + id: `4784189d-610b-4488-b3a5-5f324f752417` (string, required)
@@ -220,7 +220,7 @@ Update a company.
 
 Delete a company.
 
-+ Request (application/json;charset=utf-8)
++ Request (application/json)
 
     + Attributes (object)
         + id: `f3d67f3e-b8a9-45e8-99b1-17a3b14de8a6` (string, required)
@@ -231,7 +231,7 @@ Delete a company.
 
 Add a new or existing tag to a company.
 
-+ Request (application/json;charset=utf-8)
++ Request (application/json)
 
     + Attributes (object)
         + id: `cadd94ba-a41e-4eb4-a46e-39a7f6f96070` (string, required)
@@ -243,7 +243,7 @@ Add a new or existing tag to a company.
 
 Remove a tag from a company.
 
-+ Request (application/json;charset=utf-8)
++ Request (application/json)
 
     + Attributes (object)
         + id: `518d2e5e-99bc-4c66-8509-78e6820a1418` (string, required)

--- a/src/02-crm/contacts.apib
+++ b/src/02-crm/contacts.apib
@@ -8,7 +8,7 @@ Contacts are physical entities who are added to your CRM database. Contacts migh
 
 Get a list of contacts.
 
-+ Request (application/json;charset=utf-8)
++ Request (application/json)
 
     + Attributes (object)
         + filter (object, optional)
@@ -39,7 +39,7 @@ Get a list of contacts.
                     + field: `name`
                     + order: `asc`
 
-+ Response 200 (application/json;charset=utf-8)
++ Response 200 (application/json)
 
     + Attributes (object)
         + data (array)
@@ -79,12 +79,12 @@ Get a list of contacts.
 
 Get details for a single contact.
 
-+ Request (application/json;charset=utf-8)
++ Request (application/json)
 
     + Attributes (object)
         + id: `cde0bc5f-8602-4e12-b5d3-f03436b54c0d` (string, required)
 
-+ Response 200 (application/json;charset=utf-8)
++ Response 200 (application/json)
 
     + Attributes (object)
         + data (object)
@@ -141,7 +141,7 @@ Get details for a single contact.
 
 Add a new contact.
 
-+ Request (application/json;charset=utf-8)
++ Request (application/json)
 
     + Attributes (object)
         + first_name: `John` (string, optional)
@@ -179,7 +179,7 @@ Add a new contact.
         + custom_fields (array[CustomFieldValue], optional)
         + marketing_mails_consent: false (boolean, optional)
 
-+ Response 201 (application/json;charset=utf-8)
++ Response 201 (application/json)
 
     + Attributes (object)
         + data (object)
@@ -190,7 +190,7 @@ Add a new contact.
 
 Update a contact.
 
-+ Request (application/json;charset=utf-8)
++ Request (application/json)
 
     + Attributes (object)
         + id: `76c9d03c-ec5c-4b21-9fc6-7ffee488b12d` (string, required)
@@ -235,7 +235,7 @@ Update a contact.
 
 Delete a contact.
 
-+ Request (application/json;charset=utf-8)
++ Request (application/json)
 
     + Attributes (object)
         + id: `4e235f27-0af0-40e5-82f3-d32d0aa9edb3` (string, required)
@@ -246,7 +246,7 @@ Delete a contact.
 
 Add a new or existing tag to a contact.
 
-+ Request (application/json;charset=utf-8)
++ Request (application/json)
 
     + Attributes (object)
         + id: `cadd94ba-a41e-4eb4-a46e-39a7f6f96070` (string, required)
@@ -258,7 +258,7 @@ Add a new or existing tag to a contact.
 
 Remove a tag from a contact.
 
-+ Request (application/json;charset=utf-8)
++ Request (application/json)
 
     + Attributes (object)
         + id: `518d2e5e-99bc-4c66-8509-78e6820a1418` (string, required)
@@ -270,7 +270,7 @@ Remove a tag from a contact.
 
 Link a contact to a company.
 
-+ Request (application/json;charset=utf-8)
++ Request (application/json)
 
     + Attributes (object)
         + id: `75596038-b9c8-4a37-969d-61059e300a28` (string, required)
@@ -284,7 +284,7 @@ Link a contact to a company.
 
 Unlink a contact from a company.
 
-+ Request (application/json;charset=utf-8)
++ Request (application/json)
 
     + Attributes (object)
         + id: `b4b3160a-b55e-4033-bdae-25b6d22949b4` (string, required)

--- a/src/02-crm/tags.apib
+++ b/src/02-crm/tags.apib
@@ -6,7 +6,7 @@ Tags are used to label contacts or companies, so that they can easily be filtere
 
 Get a list of tags.
 
-+ Request (application/json;charset=utf-8)
++ Request (application/json)
 
     + Attributes (object)
         + page (Page, optional)
@@ -23,7 +23,7 @@ Get a list of tags.
                     + field: `tag`
                     + order: `asc`
 
-+ Response 200 (application/json;charset=utf-8)
++ Response 200 (application/json)
 
     + Attributes (object)
         + data (array)

--- a/src/03-deals/deal-phases.apib
+++ b/src/03-deals/deal-phases.apib
@@ -8,14 +8,14 @@ Deal phases are the different phases a deal typically goes through. A deal can b
 
 Get a list of all phases a deal can go through, sorted by their order in the flow.
 
-+ Request (application/json;charset=utf-8)
++ Request (application/json)
 
     + Attributes (object)
         + filter (object, optional)
             + ids: `53a7e592-a136-4bae-ae15-517befd3d75d`,`bb50af79-55cd-4be0-8306-e9626c70a90f` (array[string], optional)
         + page (Page, optional)
 
-+ Response 200 (application/json;charset=utf-8)
++ Response 200 (application/json)
 
     + Attributes (object)
         + data (array)

--- a/src/03-deals/deal-sources.apib
+++ b/src/03-deals/deal-sources.apib
@@ -8,7 +8,7 @@ Deal sources are used to track the origin of a deal.
 
 Get a list of all deal sources, sorted alphabetically (on name)
 
-+ Request (application/json;charset=utf-8)
++ Request (application/json)
 
     + Attributes (object)
         + filter (object, optional)
@@ -20,7 +20,7 @@ Get a list of all deal sources, sorted alphabetically (on name)
                     + field: `name`
                     + order: `asc`
 
-+ Response 200 (application/json;charset=utf-8)
++ Response 200 (application/json)
 
     + Attributes (object)
         + data (array)

--- a/src/03-deals/deals.apib
+++ b/src/03-deals/deals.apib
@@ -8,7 +8,7 @@ Deals are sale opportunities, which need to be followed up by their responsible 
 
 Get a list of deals.
 
-+ Request (application/json;charset=utf-8)
++ Request (application/json)
 
     + Attributes (object)
         + filter (object, optional)
@@ -38,7 +38,7 @@ Get a list of deals.
                     + order: `desc`
 
 
-+ Response 200 (application/json;charset=utf-8)
++ Response 200 (application/json)
 
     + Attributes (object)
         + data (array)
@@ -86,12 +86,12 @@ Get a list of deals.
 
 Get details for a single deal.
 
-+ Request (application/json;charset=utf-8)
++ Request (application/json)
 
     + Attributes (object)
         + id: `f6871b06-6513-4750-b5e6-ff3503b5a029` (string, required)
 
-+ Response 200 (application/json;charset=utf-8)
++ Response 200 (application/json)
 
     + Attributes (object)
         + data (object)
@@ -151,7 +151,7 @@ Get details for a single deal.
 
 Create a new deal for a customer.
 
-+ Request (application/json;charset=utf-8)
++ Request (application/json)
 
     + Attributes (object)
         + lead (object, required)
@@ -172,7 +172,7 @@ Create a new deal for a customer.
         + estimated_closing_date: `2017-05-09` (string, optional)
         + custom_fields (array[CustomFieldValue], optional)
 
-+ Response 201 (application/json;charset=utf-8)
++ Response 201 (application/json)
 
     + Attributes (object)
         + data (object)
@@ -183,7 +183,7 @@ Create a new deal for a customer.
 
 Update a deal.
 
-+ Request (application/json;charset=utf-8)
++ Request (application/json)
 
     + Attributes (object)
         + id: `65a35860-dcca-4850-9fd6-47ff08469e0c` (string, required)
@@ -210,7 +210,7 @@ Update a deal.
 
 Move the deal to a different phase.
 
-+ Request (application/json;charset=utf-8)
++ Request (application/json)
 
     + Attributes (object)
         + id: `e88131bf-50c4-49d3-8ae3-47e5d9626bf6` (string, required)
@@ -222,7 +222,7 @@ Move the deal to a different phase.
 
 Mark a deal as won.
 
-+ Request (application/json;charset=utf-8)
++ Request (application/json)
 
     + Attributes (object)
         + id: `e88131bf-50c4-49d3-8ae3-47e5d9626bf6` (string, required)
@@ -233,7 +233,7 @@ Mark a deal as won.
 
 Mark a deal as lost.
 
-+ Request (application/json;charset=utf-8)
++ Request (application/json)
 
     + Attributes (object)
         + id: `460df7b2-fe82-4c6c-b215-6d0a1bd3c742` (string, required)
@@ -246,7 +246,7 @@ Mark a deal as lost.
 
 Delete a deal.
 
-+ Request (application/json;charset=utf-8)
++ Request (application/json)
 
     + Attributes (object)
         + id: `4e235f27-0af0-40e5-82f3-d32d0aa9edb3` (string, required)
@@ -257,7 +257,7 @@ Delete a deal.
 
 Get a list of lost reasons for deals.
 
-+ Request (application/json;charset=utf-8)
++ Request (application/json)
 
     + Attributes (object)
         + page (Page, optional)
@@ -274,7 +274,7 @@ Get a list of lost reasons for deals.
                     + field: `name`
                     + order: `asc`
 
-+ Response 200 (application/json;charset=utf-8)
++ Response 200 (application/json)
 
     + Attributes (object)
         + data (array)

--- a/src/03-deals/quotations.apib
+++ b/src/03-deals/quotations.apib
@@ -8,12 +8,12 @@ A quotation is a sales offer for a specific customer. It is always attached to a
 
 Get a quotation
 
-+ Request (application/json;charset=utf-8)
++ Request (application/json)
 
     + Attributes (object)
         + id: `e7a3fe2b-2c75-480f-87b9-121816b5257b` (string, required)
 
-+ Response 200 (application/json;charset=utf-8)
++ Response 200 (application/json)
 
     + Attributes (object)
         + data (object)
@@ -55,7 +55,7 @@ Get a quotation
 
 Download a quotation in a specific format.
 
-+ Request (application/json;charset=utf-8)
++ Request (application/json)
 
     + Attributes (object)
         + id: `d885e5d5-bacb-4607-bde9-abc4a04a901b` (string, required)
@@ -63,7 +63,7 @@ Download a quotation in a specific format.
             + Members
                 + pdf
 
-+ Response 200 (application/json;charset=utf-8)
++ Response 200 (application/json)
 
     + Attributes (object)
         + data (object)

--- a/src/04-calendar/activity-types.apib
+++ b/src/04-calendar/activity-types.apib
@@ -6,14 +6,14 @@ Activity types identify the different types of events that take place within you
 
 Get a list of all activity types.
 
-+ Request (application/json;charset=utf-8)
++ Request (application/json)
 
     + Attributes (object)
         + filter (object, optional)
             + ids: `7fcf5609-25fe-47e2-97b2-dbd9c817796e`,`366b6100-7005-4b1b-a16a-7e88f445f496` (array[string], optional)
         + page (Page, optional)
 
-+ Response 200 (application/json;charset=utf-8)
++ Response 200 (application/json)
 
     + Attributes (object)
         + data (array)

--- a/src/04-calendar/events.apib
+++ b/src/04-calendar/events.apib
@@ -8,7 +8,7 @@ Calendar events are scheduled events in your calendar. A calendar event involves
 
 Get a list of calendar events.
 
-+ Request (application/json;charset=utf-8)
++ Request (application/json)
 
     + Attributes (object)
         + filter (object, optional)
@@ -43,7 +43,7 @@ Get a list of calendar events.
                     + field: starts_at
                     + order: asc
 
-+ Response 200 (application/json;charset=utf-8)
++ Response 200 (application/json)
 
     + Attributes (object)
         + data (array)
@@ -83,12 +83,12 @@ Get a list of calendar events.
 
 Get details for a single calendar event.
 
-+ Request (application/json;charset=utf-8)
++ Request (application/json)
 
     + Attributes (object)
         + id: `9a5a3984-abfc-40cd-a880-f97683c6a99c` (string, required)
 
-+ Response 200 (application/json;charset=utf-8)
++ Response 200 (application/json)
 
     + Attributes (object)
         + data (object)
@@ -126,7 +126,7 @@ Get details for a single calendar event.
 
 Create a new calendar event.
 
-+ Request (application/json;charset=utf-8)
++ Request (application/json)
 
     + Attributes
         + title: `Meeting with stakeholders` (string, required)
@@ -151,7 +151,7 @@ Create a new calendar event.
                         + contact
                 + id: `c9258836-f9a5-40cb-aa2a-d55c22991b93` (string, required)
 
-+ Response 201 (application/json;charset=utf-8)
++ Response 201 (application/json)
 
     + Attributes (object)
         + data (object)
@@ -162,7 +162,7 @@ Create a new calendar event.
 
 Update a calendar event.
 
-+ Request (application/json;charset=utf-8)
++ Request (application/json)
 
     + Attributes
         + id: `f22fc69d-5d07-40cf-af46-015698a74b63` (string, required)
@@ -193,7 +193,7 @@ Update a calendar event.
 
 Cancel a calendar event (for all attendees).
 
-+ Request (application/json;charset=utf-8)
++ Request (application/json)
 
     + Attributes (object)
         + id: `b519491e-ca80-4efb-bb7b-3f08544936b0` (string, required)

--- a/src/05-invoicing/credit-notes.apib
+++ b/src/05-invoicing/credit-notes.apib
@@ -8,7 +8,7 @@ Credit notes are created when certain products or services are not delivered acc
 
 List credit notes
 
-+ Request (application/json;charset=utf-8)
++ Request (application/json)
 
     + Attributes (object)
         + filter (object, optional)
@@ -28,7 +28,7 @@ List credit notes
                     + field: `credit_note_number`
                     + order: `asc`
 
-+ Response 200 (application/json;charset=utf-8)
++ Response 200 (application/json)
 
     + Attributes (object)
         + data (array)
@@ -69,12 +69,12 @@ List credit notes
 
 Get details for a single credit note
 
-+ Request (application/json;charset=utf-8)
++ Request (application/json)
 
     + Attributes (object)
         + id: `27300f09-6250-4a23-8557-d84c52f99ecf` (string, required)
 
-+ Response 200 (application/json;charset=utf-8)
++ Response 200 (application/json)
 
     + Attributes (object)
         + data (array)
@@ -153,7 +153,7 @@ Get details for a single credit note
 
 Download a credit note in a specific format.
 
-+ Request (application/json;charset=utf-8)
++ Request (application/json)
 
     + Attributes (object)
         + id: `d885e5d5-bacb-4607-bde9-abc4a04a901b` (string, required)
@@ -161,7 +161,7 @@ Download a credit note in a specific format.
             + Members
                 + pdf
 
-+ Response 200 (application/json;charset=utf-8)
++ Response 200 (application/json)
 
     + Attributes (object)
         + data (object)

--- a/src/05-invoicing/invoices.apib
+++ b/src/05-invoicing/invoices.apib
@@ -8,7 +8,7 @@ Teamleader provides a whole set of endpoints to make it easy to develop integrat
 
 Get a list of invoices.
 
-+ Request (application/json;charset=utf-8)
++ Request (application/json)
 
     + Attributes (object)
         + filter (object, optional)
@@ -33,7 +33,7 @@ Get a list of invoices.
                     + field: `invoice_number`
                     + order: `asc`
 
-+ Response 200 (application/json;charset=utf-8)
++ Response 200 (application/json)
 
     + Attributes (object)
         + data (array)
@@ -79,12 +79,12 @@ Get a list of invoices.
 
 Get details for a single invoice.
 
-+ Request (application/json;charset=utf-8)
++ Request (application/json)
 
     + Attributes (object)
         + id: `27300f09-6250-4a23-8557-d84c52f99ecf` (string)
 
-+ Response 200 (application/json;charset=utf-8)
++ Response 200 (application/json)
 
     + Attributes (object)
         + data (object)
@@ -194,7 +194,7 @@ Get details for a single invoice.
 
 Download an invoice in a specific format.
 
-+ Request (application/json;charset=utf-8)
++ Request (application/json)
 
     + Attributes (object)
         + id: `d885e5d5-bacb-4607-bde9-abc4a04a901b` (string, required)
@@ -202,7 +202,7 @@ Download an invoice in a specific format.
             + Members
                 + pdf
 
-+ Response 200 (application/json;charset=utf-8)
++ Response 200 (application/json)
 
     + Attributes (object)
         + data (object)
@@ -213,7 +213,7 @@ Download an invoice in a specific format.
 
 Draft a new invoice.
 
-+ Request (application/json;charset=utf-8)
++ Request (application/json)
 
     + Attributes (object)
         + invoicee (object, required)
@@ -262,7 +262,7 @@ Draft a new invoice.
         + note: `Invoice comments` (string, optional)
         + custom_fields (array[CustomFieldValue], optional)
 
-+ Response 201 (application/json;charset=utf-8)
++ Response 201 (application/json)
 
     + Attributes (object)
         + data (object)
@@ -273,7 +273,7 @@ Draft a new invoice.
 
 Update an invoice.
 
-+ Request (application/json;charset=utf-8)
++ Request (application/json)
 
     + Attributes (object)
         + id: `b7023c11-455e-4fa5-bb96-87f37dbc7d07` (string, required)
@@ -328,12 +328,12 @@ Update an invoice.
 
 Creates a new draft invoice based on another invoice
 
-+ Request (application/json;charset=utf-8)
++ Request (application/json)
 
     + Attributes (object)
         + id: `b7023c11-455e-4fa5-bb96-87f37dbc7d07` (string, required)
 
-+ Response 201 (application/json;charset=utf-8)
++ Response 201 (application/json)
 
     + Attributes (object)
         + data (object)
@@ -344,7 +344,7 @@ Creates a new draft invoice based on another invoice
 
 Book a draft invoice.
 
-+ Request (application/json;charset=utf-8)
++ Request (application/json)
 
     + Attributes (object)
         + id: `7abb325c-e063-42a4-8fb4-1b730759645a` (string, required)
@@ -356,7 +356,7 @@ Book a draft invoice.
 
 Delete an existing invoice. Only possible for draft invoices or the last booked invoice.
 
-+ Request (application/json;charset=utf-8)
++ Request (application/json)
 
     + Attributes (object)
         + id: `7517d21c-75c1-4b89-8956-0e67f46c8532` (string, required)
@@ -367,7 +367,7 @@ Delete an existing invoice. Only possible for draft invoices or the last booked 
 
 Register a payment for an invoice.
 
-+ Request (application/json;charset=utf-8)
++ Request (application/json)
 
     + Attributes (object)
         + id: `7abb325c-e063-42a4-8fb4-1b730759645a` (string, required)

--- a/src/05-invoicing/payment-terms.apib
+++ b/src/05-invoicing/payment-terms.apib
@@ -6,9 +6,9 @@ Payment terms are the conditions under which an invoice need to be paid.
 
 Get a list of available payment terms.
 
-+ Request (application/json;charset=utf-8)
++ Request (application/json)
 
-+ Response 200 (application/json;charset=utf-8)
++ Response 200 (application/json)
 
     + Attributes (object)
         + data (array)

--- a/src/05-invoicing/tax-rates.apib
+++ b/src/05-invoicing/tax-rates.apib
@@ -6,7 +6,7 @@ Tax rates provide an overview of different taxation rates used to bill customers
 
 Get a list of available tax rates.
 
-+ Request (application/json;charset=utf-8)
++ Request (application/json)
 
 + Attributes (object)
     + filter (object, optional)
@@ -25,7 +25,7 @@ Get a list of available tax rates.
                     + field: `description`
                     + order: `asc`
 
-+ Response 200 (application/json;charset=utf-8)
++ Response 200 (application/json)
 
     + Attributes (object)
         + data (array)

--- a/src/05-invoicing/withholding-tax-rates.apib
+++ b/src/05-invoicing/withholding-tax-rates.apib
@@ -6,13 +6,13 @@ Withholding tax rates provide an overview of different taxation rates used to bi
 
 Get a list of available withholding tax rates.
 
-+ Request (application/json;charset=utf-8)
++ Request (application/json)
 
 + Attributes (object)
     + filter (object, optional)
         + department_id: `080aac72-ff1a-4627-bfe3-146b6eee979c` (string, optional) - The ID of the department you wish to filter on.
 
-+ Response 200 (application/json;charset=utf-8)
++ Response 200 (application/json)
 
     + Attributes (object)
         + data (array)

--- a/src/06-products/product-categories.apib
+++ b/src/06-products/product-categories.apib
@@ -8,13 +8,13 @@ Product categories are used to group specific products. They can be linked to a 
 
 Get a list of product categories.
 
-+ Request (application/json;charset=utf-8)
++ Request (application/json)
 
     + Attributes (object)
         + filter (object, optional)
             + department_id: `080aac72-ff1a-4627-bfe3-146b6eee979c` (string, optional) - The ID of the department you wish to filter on.
 
-+ Response 200 (application/json;charset=utf-8)
++ Response 200 (application/json)
 
     + Attributes (object)
         + data (array)

--- a/src/06-products/products.apib
+++ b/src/06-products/products.apib
@@ -6,14 +6,14 @@
 
 Get a list of products.
 
-+ Request (application/json;charset=utf-8)
++ Request (application/json)
 
     + Attributes (object)
         + filter (object, optional)
             + ids: `bbbfe0da-e692-4ee3-9d3d-0716808d6523`,`722e1eb9-53d5-4b8c-9d17-154dcc65c610` (array[string], optional)
             + term: `cookies` (string, optional) - The name and the external id.
 
-+ Response 200 (application/json;charset=utf-8)
++ Response 200 (application/json)
 
     + Attributes (object)
         + data (array)

--- a/src/07-projects/milestones.apib
+++ b/src/07-projects/milestones.apib
@@ -8,7 +8,7 @@ Every projects consists of one or more milestones which are limited in time and 
 
 Get a list of project milestones.
 
-+ Request (application/json;charset=utf-8)
++ Request (application/json)
 
     + Attributes (object)
         + filter (object, optional)
@@ -34,7 +34,7 @@ Get a list of project milestones.
                     + field: `due_on`
                     + order: `asc`
 
-+ Response 200 (application/json;charset=utf-8)
++ Response 200 (application/json)
 
     + Attributes (object)
         + data (array)
@@ -62,12 +62,12 @@ Get a list of project milestones.
 
 Get details for a single milestone.
 
-+ Request (application/json;charset=utf-8)
++ Request (application/json)
 
     + Attributes (object)
         + id: `64349fa2-6ca2-4b19-82e6-d3258ceab2d8` (string, required)
 
-+ Response 200 (application/json;charset=utf-8)
++ Response 200 (application/json)
 
     + Attributes (object)
         + data (object)
@@ -89,7 +89,7 @@ Get details for a single milestone.
 
 Create a new milestone.
 
-+ Request (application/json;charset=utf-8)
++ Request (application/json)
 
     + Attributes (object)
         + project_id: `1c159f98-4b07-438a-9f42-fb4206b9530d` (string, required)
@@ -97,7 +97,7 @@ Create a new milestone.
         + name: `Initial setup` (string, required)
         + responsible_user_id: `e1240972-6cfc-4549-b49c-edda7568cc48` (string, required)
 
-+ Response 201 (application/json;charset=utf-8)
++ Response 201 (application/json)
 
     + Attributes (object)
         + data (object)
@@ -108,7 +108,7 @@ Create a new milestone.
 
 Update a milestone.
 
-+ Request (application/json;charset=utf-8)
++ Request (application/json)
 
     + Attributes (object)
         + id: `67e80ad8-d14f-4510-a2bd-a4c6aa578c37` (string, required)
@@ -116,4 +116,4 @@ Update a milestone.
         + name: `Initial setup` (string, optional)
         + responsible_user_id: `e1240972-6cfc-4549-b49c-edda7568cc48` (string, optional)
 
-+ Response 204 (application/json;charset=utf-8)
++ Response 204 (application/json)

--- a/src/07-projects/project-items.apib
+++ b/src/07-projects/project-items.apib
@@ -8,7 +8,7 @@ Project items are added to a project and they affect the profitability. This inf
 
 Get a list of project items.
 
-+ Request (application/json;charset=utf-8)
++ Request (application/json)
 
     + Attributes (object)
         + filter (object, optional)
@@ -39,7 +39,7 @@ Get a list of project items.
                     + field: `occurred_at`
                     + order: `desc`
 
-+ Response 200 (application/json;charset=utf-8)
++ Response 200 (application/json)
 
     + Attributes (object)
         + data (array)
@@ -77,12 +77,12 @@ Get a list of project items.
 
 Get details for a single project item.
 
-+ Request (application/json;charset=utf-8)
++ Request (application/json)
 
     + Attributes (object)
         + id: `8a04371b-2ffb-407b-9b24-d5b5452009c7` (string, required)
 
-+ Response 200 (application/json;charset=utf-8)
++ Response 200 (application/json)
 
     + Attributes (object)
         + data (object)

--- a/src/07-projects/projects.apib
+++ b/src/07-projects/projects.apib
@@ -8,7 +8,7 @@ Projects allow users to work together as a team on a single project. They consis
 
 Get a list of projects.
 
-+ Request (application/json;charset=utf-8)
++ Request (application/json)
 
     + Attributes (object)
         + filter (object, optional)
@@ -40,7 +40,7 @@ Get a list of projects.
                     + field: `due_on`
                     + order: `asc`
 
-+ Response 200 (application/json;charset=utf-8)
++ Response 200 (application/json)
 
     + Attributes (object)
         + data (array)
@@ -69,12 +69,12 @@ Get a list of projects.
 
 Get details for a single project.
 
-+ Request (application/json;charset=utf-8)
++ Request (application/json)
 
     + Attributes (object)
         + id: `8a04371b-2ffb-407b-9b24-d5b5452009c7` (string, required)
 
-+ Response 200 (application/json;charset=utf-8)
++ Response 200 (application/json)
 
     + Attributes (object)
         + data (object)
@@ -120,7 +120,7 @@ Get details for a single project.
 
 Create a new project.
 
-+ Request (application/json;charset=utf-8)
++ Request (application/json)
 
     + Attributes (object)
         + title: `New company website` (string, required)
@@ -148,7 +148,7 @@ Create a new project.
                     + company
             + id: `ebafa4c5-fa8a-4409-92e5-1b192243372f` (string, required)
 
-+ Response 201 (application/json;charset=utf-8)
++ Response 201 (application/json)
 
     + Attributes (object)
         + data (object)
@@ -160,7 +160,7 @@ Create a new project.
 
 Update a project.
 
-+ Request (application/json;charset=utf-8)
++ Request (application/json)
 
     + Attributes (object)
         + id: `dcc2e8ed-51be-4cb6-9c01-034aedac86fd` (string, required)
@@ -174,26 +174,26 @@ Update a project.
                 + cancelled
         + starts_on: `2016-02-04` (string, required)
 
-+ Response 204 (application/json;charset=utf-8)
++ Response 204 (application/json)
 
 
 ### projects.delete [POST /projects.delete]
 
 Delete a project.
 
-+ Request (application/json;charset=utf-8)
++ Request (application/json)
 
     + Attributes (object)
         + id: `01548b10-4932-4a18-8a89-005ad09db2c8` (string, required)
 
-+ Response 204 (application/json;charset=utf-8)
++ Response 204 (application/json)
 
 
 ### projects.addParticipant [POST /projects.addParticipant]
 
 Add a participant to a project.
 
-+ Request (application/json;charset=utf-8)
++ Request (application/json)
 
     + Attributes (object)
         + id: `8dbfa9db-c53f-410c-97d3-755b19685809` (string, required)
@@ -213,7 +213,7 @@ Add a participant to a project.
 
 Update a participant's role for a project.
 
-+ Request (application/json;charset=utf-8)
++ Request (application/json)
 
     + Attributes (object)
         + id: `55fbe14f-7399-48e5-b4e0-64b7f5c50451` (string, required)

--- a/src/08-tasks/tasks.apib
+++ b/src/08-tasks/tasks.apib
@@ -4,7 +4,7 @@
 
 Get a list of tasks.
 
-+ Request (application/json;charset=utf-8)
++ Request (application/json)
 
     + Attributes (object)
         + filter (object, optional)
@@ -24,7 +24,7 @@ Get a list of tasks.
                     + field: `due_at`
                     + order: `asc`
 
-+ Response 200 (application/json;charset=utf-8)
++ Response 200 (application/json)
 
     + Attributes (object)
         + data (array)
@@ -53,12 +53,12 @@ Get a list of tasks.
 
 Get information about a task.
 
-+ Request (application/json;charset=utf-8)
++ Request (application/json)
 
     + Attributes (object)
         + id: `6fac0bf0-e803-424e-af67-76863a3d7d16` (string, required)
 
-+ Response 200 (application/json;charset=utf-8)
++ Response 200 (application/json)
 
     + Attributes (object)
         + data (object)
@@ -86,7 +86,7 @@ Get information about a task.
 
 Create a new task.
 
-+ Request (application/json;charset=utf-8)
++ Request (application/json)
 
     + Attributes (object)
         + description (string, required)
@@ -104,7 +104,7 @@ Create a new task.
                     + team
             + id: `f29abf48-337d-44b4-aad4-585f5277a456` (string)
 
-+ Response 201 (application/json;charset=utf-8)
++ Response 201 (application/json)
 
     + Attributes (object)
         + data (object)
@@ -115,7 +115,7 @@ Create a new task.
 
 Update a task.
 
-+ Request (application/json;charset=utf-8)
++ Request (application/json)
 
     + Attributes (object)
         + id: `00ed6266-a5bd-4aac-a292-2582017b6400` (string, required)
@@ -140,7 +140,7 @@ Update a task.
 
 Delete a task.
 
-+ Request (application/json;charset=utf-8)
++ Request (application/json)
 
     + Attributes (object)
         + id: `5f0afd8a-8a40-48a4-bbe6-7d0e9c61bb6d` (string, required)

--- a/src/09-workorders/work-orders.apib
+++ b/src/09-workorders/work-orders.apib
@@ -4,12 +4,12 @@
 
 Get details for a single work order.
 
-+ Request (application/json;charset=utf-8)
++ Request (application/json)
 
     + Attributes (object)
         + id: `cde0bc5f-8602-4e12-b5d3-f03436b54c0d` (string, required)
 
-+ Response 200 (application/json;charset=utf-8)
++ Response 200 (application/json)
 
     + Attributes (object)
         + data (object)
@@ -58,7 +58,7 @@ Get details for a single work order.
 
 Add a draft work order.
 
-+ Request (application/json;charset=utf-8)
++ Request (application/json)
 
     + Attributes (object)
        + customer (object, required)
@@ -84,7 +84,7 @@ Add a draft work order.
                + product_id: `e2314517-3cab-4aa9-8471-450e73449040` (string, required)
                + quantity: 3 (number, required)
 
-+ Response 201 (application/json;charset=utf-8)
++ Response 201 (application/json)
 
     + Attributes (object)
         + data (object)
@@ -95,7 +95,7 @@ Add a draft work order.
 
 Update a draft work order.
 
-+ Request (application/json;charset=utf-8)
++ Request (application/json)
 
     + Attributes (object)
         + id: `4afb0a9c-91c6-49ed-a2e5-ce7c1e3a87fb` (string, required)
@@ -118,7 +118,7 @@ Update a draft work order.
 
 Finalize a draft work order. This will also generate the work order PDF.
 
-+ Request (application/json;charset=utf-8)
++ Request (application/json)
 
     + Attributes (object)
        + id: `4afb0a9c-91c6-49ed-a2e5-ce7c1e3a87fb` (string, required)
@@ -129,7 +129,7 @@ Finalize a draft work order. This will also generate the work order PDF.
 
 Send a finalized work order to the customer.
 
-+ Request (application/json;charset=utf-8)
++ Request (application/json)
 
     + Attributes (object)
         + id: `4afb0a9c-91c6-49ed-a2e5-ce7c1e3a87fb` (string, required)

--- a/src/99-other/migrating.apib
+++ b/src/99-other/migrating.apib
@@ -7,7 +7,7 @@ Their only use is to allow older integrations to migrate their data to the new A
 
 Translates an ID from the deprecated API into a new UUID.
 
-+ Request (application/json;charset=utf-8)
++ Request (application/json)
 
     + Attributes (object)
         + type: `contact` (enum[string])
@@ -59,7 +59,7 @@ Translates an ID from the deprecated API into a new UUID.
 
 Translates tax rates from the deprecated API into a new UUID tax rate.
 
-+ Request (application/json;charset=utf-8)
++ Request (application/json)
 
     + Attributes (object)
         + department_id: `6ad54ec6-ee2d-4500-afe6-0917c1aa7a38` (string)
@@ -76,7 +76,7 @@ Translates tax rates from the deprecated API into a new UUID tax rate.
 
 Translates "meeting", "call" and "task" into their respective activity type UUID.
 
-+ Request (application/json;charset=utf-8)
++ Request (application/json)
 
     + Attributes (object)
         + type: `meeting` (enum[string])

--- a/src/99-other/webhooks.apib
+++ b/src/99-other/webhooks.apib
@@ -4,7 +4,7 @@
 
 Register a new webhook.
 
-+ Request (application/json;charset=utf-8)
++ Request (application/json)
 
     + Attributes (WebHook)
 
@@ -14,9 +14,9 @@ Register a new webhook.
 
 List registered webhooks ordered by URL.
 
-+ Request (application/json;charset=utf-8)
++ Request (application/json)
 
-+ Response 200 (application/json;charset=utf-8)
++ Response 200 (application/json)
 
     + Attributes (object)
         + data (array[WebHook])
@@ -25,7 +25,7 @@ List registered webhooks ordered by URL.
 
 Unregister a webhook.
 
-+ Request (application/json;charset=utf-8)
++ Request (application/json)
 
     + Attributes (WebHook)
 

--- a/src/authentication.apib
+++ b/src/authentication.apib
@@ -72,7 +72,7 @@ These access tokens are also known as bearer tokens. You can use this token to c
 ```
 GET https://api.teamleader.eu/contacts.list HTTP/1.1
 Authorization: Bearer eyJ0eXAiOiJKV1QiLCJhbGciO...
-Accept: application/json;charset=utf-8
+Accept: application/json
 ```
 
 Access tokens expire shortly (usually 1 hour) after they are issued for security reasons. If your integration needs to communicate with our API beyond the access token's lifespan, you will need to request a new access token using the refresh token which was issued with the access token. Note that refresh tokens can only be used once to get a new access token and refresh token.


### PR DESCRIPTION
We removed the `charset=utf-8` from content-type in requests and responses.

Let's make this consistent in this feature branch. 