### PR TITLE
[TOOL-174] Add `status` to `/users.info`

### DIFF
--- a/apiary.apib
+++ b/apiary.apib
@@ -633,6 +633,10 @@ Get details for a single user.
                     + tr-TR
             + function: `Sales` (string)
             + time_zone: `Europe/Brussels` (string)
+            + status: `active` (enum[string])
+                + Members
+                    + active
+                    + deactivated
 
 ## Custom Fields [/customFieldDefinitions]
 

--- a/apiary.apib
+++ b/apiary.apib
@@ -370,6 +370,8 @@ We list all backwards-compatible additions here. These are currently available i
 
 #### Latest
 
+- In `users.info`, we added the `status` property to the response since it is now possible to retrieve deactivated users.
+
 - In `users.list`, you can now also request deactivated users, by using a new filter on `status`.  
   By default, the endpoint keeps returning active users only. The status is also returned in the response data.
 

--- a/src/01-general/users.apib
+++ b/src/01-general/users.apib
@@ -129,3 +129,7 @@ Get details for a single user.
                     + tr-TR
             + function: `Sales` (string)
             + time_zone: `Europe/Brussels` (string)
+            + status: `active` (enum[string])
+                + Members
+                    + active
+                    + deactivated

--- a/src/changes-backwards-compatible.apib
+++ b/src/changes-backwards-compatible.apib
@@ -6,6 +6,8 @@ We list all backwards-compatible additions here. These are currently available i
 
 #### Latest
 
+- In `users.info`, we added the `status` property to the response since it is now possible to retrieve deactivated users.
+
 - In `users.list`, you can now also request deactivated users, by using a new filter on `status`.  
   By default, the endpoint keeps returning active users only. The status is also returned in the response data.
 


### PR DESCRIPTION
The `/users.list` now allows the integrators to filter by `active` and `deactivated` users, with this change now makes sense to display the user status in this endpoint and allow deactivated users to be returned.