### PR TITLE
Fix array of strings

### DIFF
--- a/apiary.apib
+++ b/apiary.apib
@@ -585,11 +585,10 @@ Get a list of all users.
         + filter (object, optional)
             + ids: `cb8da52a-ce89-4bf6-8f7e-8ee6cb85e3b5`,`f8a57a6f-dd1e-41a3-b8d3-428663f1d09e` (array[string], optional)
             + term: `John` (string, optional) - Filters on first name, last name and email
-            + status: `active`, `deactivated` (array[string], optional) - Filters on status
-                + (enum[string])
-                    + Members
-                        + active - Filters on active users
-                        + deactivated - Filters on deactivated users
+            + status (array[enum[string]], optional) - Filters on status
+                + Members
+                    + active - Filters on active users
+                    + deactivated - Filters on deactivated users
         + sort (array, optional)
             + (object)
                 + field (enum[string], required)
@@ -2095,8 +2094,8 @@ Get a list of invoices.
     + Attributes (object)
         + filter (object, optional)
             + department_id: `080aac72-ff1a-4627-bfe3-146b6eee979c` (string, optional) - The ID of the department you wish to filter on.
-            + status: `outstanding`, `matched` (array[string], optional) - The statuses you want to filter by.
-                + (enum[string])
+            + status (array[enum[string]], optional) - The statuses you want to filter by.
+                + Members
                     + draft
                     + outstanding
                     + matched

--- a/src/01-general/users.apib
+++ b/src/01-general/users.apib
@@ -51,11 +51,10 @@ Get a list of all users.
         + filter (object, optional)
             + ids: `cb8da52a-ce89-4bf6-8f7e-8ee6cb85e3b5`,`f8a57a6f-dd1e-41a3-b8d3-428663f1d09e` (array[string], optional)
             + term: `John` (string, optional) - Filters on first name, last name and email
-            + status: `active`, `deactivated` (array[string], optional) - Filters on status
-                + (enum[string])
-                    + Members
-                        + active - Filters on active users
-                        + deactivated - Filters on deactivated users
+            + status (array[enum[string]], optional) - Filters on status
+                + Members
+                    + active - Filters on active users
+                    + deactivated - Filters on deactivated users
         + sort (array, optional)
             + (object)
                 + field (enum[string], required)

--- a/src/05-invoicing/invoices.apib
+++ b/src/05-invoicing/invoices.apib
@@ -13,8 +13,8 @@ Get a list of invoices.
     + Attributes (object)
         + filter (object, optional)
             + department_id: `080aac72-ff1a-4627-bfe3-146b6eee979c` (string, optional) - The ID of the department you wish to filter on.
-            + status: `outstanding`, `matched` (array[string], optional) - The statuses you want to filter by.
-                + (enum[string])
+            + status (array[enum[string]], optional) - The statuses you want to filter by.
+                + Members
                     + draft
                     + outstanding
                     + matched


### PR DESCRIPTION
Is this a bug? Do we want this? 
- Removing the `string` at the end of the array
- Removing the values that look like duplicated values

Transforms this:

![image](https://user-images.githubusercontent.com/9110098/57087551-35188780-6cf8-11e9-8de7-31e785f97fcd.png)

Into this:

![image](https://user-images.githubusercontent.com/9110098/57125265-b0258080-6d80-11e9-9637-5b03794c6be7.png)
