### PR TITLE
Follow up | Nullable Customer

### DIFF
--- a/apiary.apib
+++ b/apiary.apib
@@ -3598,7 +3598,7 @@ Get a list of work orders.
                         + draft
                         + finalized
                         + sent
-                + customer (object)
+                + customer (object, nullable)
                     + type (enum[string])
                         + Members
                             + contact
@@ -3640,7 +3640,7 @@ Get details for a single work order.
                     + draft
                     + finalized
                     + sent
-            + customer (object)
+            + customer (object, nullable)
                 + type (enum[string])
                     + Members
                         + contact

--- a/src/09-workorders/work-orders.apib
+++ b/src/09-workorders/work-orders.apib
@@ -39,7 +39,7 @@ Get a list of work orders.
                         + draft
                         + finalized
                         + sent
-                + customer (object)
+                + customer (object, nullable)
                     + type (enum[string])
                         + Members
                             + contact
@@ -81,7 +81,7 @@ Get details for a single work order.
                     + draft
                     + finalized
                     + sent
-            + customer (object)
+            + customer (object, nullable)
                 + type (enum[string])
                     + Members
                         + contact


### PR DESCRIPTION
While preparing a WorkOrder from a meeting we allow to create one without an associated customer so we should document this scenario in the info and list endpoints.