### PR TITLE
PRO 1866 events.list: add filter by ids

### DIFF
--- a/apiary.apib
+++ b/apiary.apib
@@ -1867,6 +1867,7 @@ Get a list of calendar events.
 
     + Attributes (object)
         + filter (object, optional)
+            + ids: `9c475de2-1e99-0328-bc19-271b27e921d8`,`6325b4e5-c6a6-060b-b010-b81892e82fa7` (array[string], optional)
             + user_id: `5309c8c9-e313-47b0-90ba-6850c3dc3e33` (string, optional)
             + activity_type_id: `edd94120-63e2-4b10-80ed-fdfcfaa0a515` (string, optional)
             + ends_after: `2017-01-01T00:00:00+00:00` (string, optional) - Start of the period for which to return events

--- a/apiary.apib
+++ b/apiary.apib
@@ -386,6 +386,8 @@ We list all backwards-compatible additions here. These are currently available i
 
 - We added `currency_exchange_rate` to `quotations.info`.
 
+- The `events.list` endpoint now has an optional filter property `ids`.
+
 #### March 2019
 
 - On `invoices.draft` and `invoices.update` you can now also provide (a) global discount(s) through the `discounts` property.

--- a/src/04-calendar/events.apib
+++ b/src/04-calendar/events.apib
@@ -12,6 +12,7 @@ Get a list of calendar events.
 
     + Attributes (object)
         + filter (object, optional)
+            + ids: `9c475de2-1e99-0328-bc19-271b27e921d8`,`6325b4e5-c6a6-060b-b010-b81892e82fa7` (array[string], optional)
             + user_id: `5309c8c9-e313-47b0-90ba-6850c3dc3e33` (string, optional)
             + activity_type_id: `edd94120-63e2-4b10-80ed-fdfcfaa0a515` (string, optional)
             + ends_after: `2017-01-01T00:00:00+00:00` (string, optional) - Start of the period for which to return events

--- a/src/changes-backwards-compatible.apib
+++ b/src/changes-backwards-compatible.apib
@@ -22,6 +22,8 @@ We list all backwards-compatible additions here. These are currently available i
 
 - We added `currency_exchange_rate` to `quotations.info`.
 
+- The `events.list` endpoint now has an optional filter property `ids`.
+
 #### March 2019
 
 - On `invoices.draft` and `invoices.update` you can now also provide (a) global discount(s) through the `discounts` property.


### PR DESCRIPTION
Add filter by id in the `events.list` endpoint, so sideloading works correctly.

E2E Tests: https://github.com/teamleadercrm/api-tests/pull/672
Implementation PR: https://github.com/teamleadercrm/core/pull/9768