### PR TITLE
timeTracking.list returns results in descending order

### DIFF
--- a/src/08-time-tracking/time-tracking.apib
+++ b/src/08-time-tracking/time-tracking.apib
@@ -23,11 +23,11 @@ Get a list of tracked time.
                         + started_on
                 + order (enum[string], optional)
                     + Members
-                        + asc
+                        + desc
             + Default
                 + (object)
                     + field: `started_on`
-                    + order: `asc`
+                    + order: `desc`
 
 + Response 200 (application/json)
 


### PR DESCRIPTION
Results are returned in descending order, API docs said ascending. This fixes it.