### PR TITLE
[CAL-1391] Add milestone_id and deal_id to /tasks.create and /tasks.update

### DIFF
--- a/apiary.apib
+++ b/apiary.apib
@@ -371,7 +371,9 @@ We list all backwards-compatible additions here. These are currently available i
 
 #### Latest
 
-- We added `sent` as a boolean to `invoices.info` and `invoices.list`
+- In order to link milestones and deals to a task, we added `milestone_id` and `deal_id` as optional parameters to `tasks.create` and `tasks.update`.
+
+- We added `sent` as a boolean to `invoices.info` and `invoices.list`.
 
 - We added an optional filter on `ids` to `invoices.list`.
 
@@ -3369,6 +3371,8 @@ Create a new task.
         + description (string, required)
         + due_at: `2016-02-04T16:44:33+00:00` (string, required)
         + work_type_id: `32665afd-1818-0ed3-9e18-a603a3a21b95` (string, required)
+        + milestone_id: `32665afd-1818-0ed3-9e18-a603a3a21b95` (string, optional)
+        + deal_id: `32665afd-1818-0ed3-9e18-a603a3a21b95` (string, optional)
         + estimated_duration (object, optional)
             + unit: `min` (enum[string], required)
                 + Members
@@ -3399,6 +3403,8 @@ Update a task.
         + description (string, optional)
         + due_at: `2016-02-04T16:44:33+00:00` (string, optional)
         + work_type_id: `32665afd-1818-0ed3-9e18-a603a3a21b95` (string, optional)
+        + milestone_id: `32665afd-1818-0ed3-9e18-a603a3a21b95` (string, optional, nullable)
+        + deal_id: `32665afd-1818-0ed3-9e18-a603a3a21b95` (string, optional, nullable)
         + estimated_duration (object, optional)
             + unit: `min` (enum[string], required)
                 + Members

--- a/src/08-tasks/tasks.apib
+++ b/src/08-tasks/tasks.apib
@@ -125,8 +125,8 @@ Update a task.
         + description (string, optional)
         + due_at: `2016-02-04T16:44:33+00:00` (string, optional)
         + work_type_id: `32665afd-1818-0ed3-9e18-a603a3a21b95` (string, optional)
-        + milestone_id: `32665afd-1818-0ed3-9e18-a603a3a21b95` (string, optional)
-        + deal_id: `32665afd-1818-0ed3-9e18-a603a3a21b95` (string, optional)
+        + milestone_id: `32665afd-1818-0ed3-9e18-a603a3a21b95` (string, optional, nullable)
+        + deal_id: `32665afd-1818-0ed3-9e18-a603a3a21b95` (string, optional, nullable)
         + estimated_duration (object, optional)
             + unit: `min` (enum[string], required)
                 + Members

--- a/src/08-tasks/tasks.apib
+++ b/src/08-tasks/tasks.apib
@@ -92,6 +92,8 @@ Create a new task.
         + description (string, required)
         + due_at: `2016-02-04T16:44:33+00:00` (string, required)
         + work_type_id: `32665afd-1818-0ed3-9e18-a603a3a21b95` (string, required)
+        + milestone_id: `32665afd-1818-0ed3-9e18-a603a3a21b95` (string, optional)
+        + deal_id: `32665afd-1818-0ed3-9e18-a603a3a21b95` (string, optional)
         + estimated_duration (object, optional)
             + unit: `min` (enum[string], required)
                 + Members

--- a/src/08-tasks/tasks.apib
+++ b/src/08-tasks/tasks.apib
@@ -124,6 +124,8 @@ Update a task.
         + description (string, optional)
         + due_at: `2016-02-04T16:44:33+00:00` (string, optional)
         + work_type_id: `32665afd-1818-0ed3-9e18-a603a3a21b95` (string, optional)
+        + milestone_id: `32665afd-1818-0ed3-9e18-a603a3a21b95` (string, optional)
+        + deal_id: `32665afd-1818-0ed3-9e18-a603a3a21b95` (string, optional)
         + estimated_duration (object, optional)
             + unit: `min` (enum[string], required)
                 + Members

--- a/src/changes-backwards-compatible.apib
+++ b/src/changes-backwards-compatible.apib
@@ -7,7 +7,8 @@ We list all backwards-compatible additions here. These are currently available i
 #### Latest
 
 - In order to link milestones and deals to a task, we added `milestone_id` and `deal_id` as optional parameters to `tasks.create` and `tasks.update`.
-- We added `sent` as a boolean to `invoices.info` and `invoices.list`
+
+- We added `sent` as a boolean to `invoices.info` and `invoices.list`.
 
 - We added an optional filter on `ids` to `invoices.list`.
 
@@ -17,16 +18,16 @@ We list all backwards-compatible additions here. These are currently available i
 
 - In `users.info`, we added the `status` property to the response since it is now possible to retrieve deactivated users.
 
-- In `users.list`, you can now also request deactivated users, by using a new filter on `status`.
+- In `users.list`, you can now also request deactivated users, by using a new filter on `status`.  
   By default, the endpoint keeps returning active users only. The status is also returned in the response data.
 
-- We've added a `products.add` endpoint.
+- We've added a `products.add` endpoint.  
   Because you can provide the selling price of a product in this endpoint, we also return it in `products.info` from now on.
 
-- We now also return the `payment_reference` of an invoice in the `invoices.list`.
+- We now also return the `payment_reference` of an invoice in the `invoices.list`.  
   We also made it filterable through the `payment_reference` filter.
 
-- We added the `purchase_order_number` to all relevant endpoints (`invoices.draft`, `invoices.update`, `invoices.info` and `invoices.list`).
+- We added the `purchase_order_number` to all relevant endpoints (`invoices.draft`, `invoices.update`, `invoices.info` and `invoices.list`).  
   The property is also filterable through the `purchase_order_number` filter.
 
 - We added `currency_exchange_rate` to `quotations.info`.
@@ -43,7 +44,7 @@ We list all backwards-compatible additions here. These are currently available i
 
 - We've published a bunch of `tasks` endpoints (`tasks.list`, `tasks.info`, `tasks.create`, `tasks.update`, `tasks.delete`).
 
-- We now also return a `currency_exchange_rate` on all `.info` endpoints where we support multi-currency.
+- We now also return a `currency_exchange_rate` on all `.info` endpoints where we support multi-currency.  
   That is `quotations.info`, `invoices.info` and `creditNotes.info`.
 
 #### February 2019

--- a/src/changes-backwards-compatible.apib
+++ b/src/changes-backwards-compatible.apib
@@ -6,6 +6,7 @@ We list all backwards-compatible additions here. These are currently available i
 
 #### Latest
 
+- In order to link milestones and deals to a task, we added `milestone_id` and `deal_id` as optional parameters to `tasks.create` and `tasks.update`.
 - We added `sent` as a boolean to `invoices.info` and `invoices.list`
 - We added an optional filter on `ids` to `invoices.list`.
 
@@ -13,16 +14,16 @@ We list all backwards-compatible additions here. These are currently available i
 
 - In `users.info`, we added the `status` property to the response since it is now possible to retrieve deactivated users.
 
-- In `users.list`, you can now also request deactivated users, by using a new filter on `status`.  
+- In `users.list`, you can now also request deactivated users, by using a new filter on `status`.
   By default, the endpoint keeps returning active users only. The status is also returned in the response data.
 
-- We've added a `products.add` endpoint.  
+- We've added a `products.add` endpoint.
   Because you can provide the selling price of a product in this endpoint, we also return it in `products.info` from now on.
 
-- We now also return the `payment_reference` of an invoice in the `invoices.list`.  
+- We now also return the `payment_reference` of an invoice in the `invoices.list`.
   We also made it filterable through the `payment_reference` filter.
 
-- We added the `purchase_order_number` to all relevant endpoints (`invoices.draft`, `invoices.update`, `invoices.info` and `invoices.list`).  
+- We added the `purchase_order_number` to all relevant endpoints (`invoices.draft`, `invoices.update`, `invoices.info` and `invoices.list`).
   The property is also filterable through the `purchose_order_number` filter.
 
 - We added `currency_exchange_rate` to `quotations.info`.
@@ -33,5 +34,5 @@ We list all backwards-compatible additions here. These are currently available i
 
 - We've published a bunch of `tasks` endpoints (`tasks.list`, `tasks.info`, `tasks.create`, `tasks.update`, `tasks.delete`).
 
-- We now also return a `currency_exchange_rate` on all `.info` endpoints where we support multi-currency.  
+- We now also return a `currency_exchange_rate` on all `.info` endpoints where we support multi-currency.
   That is `quotations.info`, `invoices.info` and `creditNotes.info`.


### PR DESCRIPTION
**TICKET: https://teamleader.atlassian.net/browse/CAL-1391**

As an API consumer, I want to be able to link a Milestone or a Deal to a Task, for that to be possible we need to add an optional milestone_id and deal_id to /tasks.create and /tasks.update