### PR TITLE
Add ability to have WorkOrder materials without product ID

### DIFF
--- a/apiary.apib
+++ b/apiary.apib
@@ -3677,7 +3677,7 @@ Get details for a single work order.
                         + id: `e2314517-3cab-4aa9-8471-450e73449040` (string)
                     + quantity: 3 (number)
                     + name: `1/2" pipe` (string)
-                    + price: 30.20 (number)
+                    + unit_price (Money)
             + images (array) - Only included with request parameter `includes=images`.
                 + (object)
                     + id: `a856642a-a476-4b69-8e42-e7d1badb2ce9` (string)
@@ -3719,10 +3719,10 @@ Add a draft work order.
                    + Properties
                        + product_id: `e2314517-3cab-4aa9-8471-450e73449040` (string, required)
                        + name: `1/2" pipe` (string, optional)
-                       + price: 30.20 (number, optional)
+                       + unit_price (Money, optional)
                    + Properties
                        + name: `1/2" pipe` (string, required)
-                       + price: 30.20 (number, required)
+                       + unit_price (Money, required)
 
 + Response 201 (application/json)
 
@@ -3764,10 +3764,10 @@ Update a draft work order.
                     + Properties
                         + product_id: `e2314517-3cab-4aa9-8471-450e73449040` (string, required)
                         + name: `1/2" pipe` (string, optional, nullable)
-                        + price: 30.20 (number, optional, nullable)
+                        + unit_price (Money, optional, nullable)
                     + Properties
                         + name: `1/2" pipe` (string, required)
-                        + price: 30.20 (number, required)
+                        + unit_price (Money, required)
 
 + Response 204
 

--- a/apiary.apib
+++ b/apiary.apib
@@ -3672,10 +3672,12 @@ Get details for a single work order.
                     + description: `Replacing pipework` (string)
             + materials (array)
                 + (object)
-                    + product (object)
+                    + product (object, nullable)
                         + type: `product` (string)
                         + id: `e2314517-3cab-4aa9-8471-450e73449040` (string)
                     + quantity: 3 (number)
+                    + name: `1/2" pipe` (string)
+                    + price: 30.20 (number)
             + images (array) - Only included with request parameter `includes=images`.
                 + (object)
                     + id: `a856642a-a476-4b69-8e42-e7d1badb2ce9` (string)
@@ -3712,8 +3714,15 @@ Add a draft work order.
                + description: `Replacing pipework` (string, optional)
        + materials (array, optional)
            + (object)
-               + product_id: `e2314517-3cab-4aa9-8471-450e73449040` (string, required)
                + quantity: 3 (number, required)
+               + One Of
+                   + Properties
+                       + product_id: `e2314517-3cab-4aa9-8471-450e73449040` (string, required)
+                       + name: `1/2" pipe` (string, optional)
+                       + price: 30.20 (number, optional)
+                   + Properties
+                       + name: `1/2" pipe` (string, required)
+                       + price: 30.20 (number, required)
 
 + Response 201 (application/json)
 
@@ -3750,8 +3759,15 @@ Update a draft work order.
                 + description (string, optional)
         + materials (array, optional)
             + (object)
-                + product_id: `e2314517-3cab-4aa9-8471-450e73449040` (string, required)
                 + quantity: `2.2` (number, required)
+                + One Of
+                    + Properties
+                        + product_id: `e2314517-3cab-4aa9-8471-450e73449040` (string, required)
+                        + name: `1/2" pipe` (string, optional, nullable)
+                        + price: 30.20 (number, optional, nullable)
+                    + Properties
+                        + name: `1/2" pipe` (string, required)
+                        + price: 30.20 (number, required)
 
 + Response 204
 

--- a/src/09-workorders/work-orders.apib
+++ b/src/09-workorders/work-orders.apib
@@ -118,7 +118,7 @@ Get details for a single work order.
                         + id: `e2314517-3cab-4aa9-8471-450e73449040` (string)
                     + quantity: 3 (number)
                     + name: `1/2" pipe` (string)
-                    + price: 30.20 (number)
+                    + unit_price: 30.20 (number)
             + images (array) - Only included with request parameter `includes=images`.
                 + (object)
                     + id: `a856642a-a476-4b69-8e42-e7d1badb2ce9` (string)
@@ -160,10 +160,10 @@ Add a draft work order.
                    + Properties
                        + product_id: `e2314517-3cab-4aa9-8471-450e73449040` (string, required)
                        + name: `1/2" pipe` (string, optional)
-                       + price: 30.20 (number, optional)
+                       + unit_price: 30.20 (number, optional)
                    + Properties
                        + name: `1/2" pipe` (string, required)
-                       + price: 30.20 (number, required)
+                       + unit_price: 30.20 (number, required)
 
 + Response 201 (application/json)
 
@@ -205,10 +205,10 @@ Update a draft work order.
                     + Properties
                         + product_id: `e2314517-3cab-4aa9-8471-450e73449040` (string, required)
                         + name: `1/2" pipe` (string, optional, nullable)
-                        + price: 30.20 (number, optional, nullable)
+                        + unit_price: 30.20 (number, optional, nullable)
                     + Properties
                         + name: `1/2" pipe` (string, required)
-                        + price: 30.20 (number, required)
+                        + unit_price: 30.20 (number, required)
 
 + Response 204
 

--- a/src/09-workorders/work-orders.apib
+++ b/src/09-workorders/work-orders.apib
@@ -113,10 +113,12 @@ Get details for a single work order.
                     + description: `Replacing pipework` (string)
             + materials (array)
                 + (object)
-                    + product (object)
+                    + product (object, nullable)
                         + type: `product` (string)
                         + id: `e2314517-3cab-4aa9-8471-450e73449040` (string)
                     + quantity: 3 (number)
+                    + description: `1/2" pipe` (string)
+                    + price: 30.20 (number)
             + images (array) - Only included with request parameter `includes=images`.
                 + (object)
                     + id: `a856642a-a476-4b69-8e42-e7d1badb2ce9` (string)

--- a/src/09-workorders/work-orders.apib
+++ b/src/09-workorders/work-orders.apib
@@ -118,7 +118,7 @@ Get details for a single work order.
                         + id: `e2314517-3cab-4aa9-8471-450e73449040` (string)
                     + quantity: 3 (number)
                     + name: `1/2" pipe` (string)
-                    + unit_price: 30.20 (number)
+                    + unit_price (Money)
             + images (array) - Only included with request parameter `includes=images`.
                 + (object)
                     + id: `a856642a-a476-4b69-8e42-e7d1badb2ce9` (string)
@@ -160,10 +160,10 @@ Add a draft work order.
                    + Properties
                        + product_id: `e2314517-3cab-4aa9-8471-450e73449040` (string, required)
                        + name: `1/2" pipe` (string, optional)
-                       + unit_price: 30.20 (number, optional)
+                       + unit_price (Money, optional)
                    + Properties
                        + name: `1/2" pipe` (string, required)
-                       + unit_price: 30.20 (number, required)
+                       + unit_price (Money, required)
 
 + Response 201 (application/json)
 
@@ -205,10 +205,10 @@ Update a draft work order.
                     + Properties
                         + product_id: `e2314517-3cab-4aa9-8471-450e73449040` (string, required)
                         + name: `1/2" pipe` (string, optional, nullable)
-                        + unit_price: 30.20 (number, optional, nullable)
+                        + unit_price (Money, optional, nullable)
                     + Properties
                         + name: `1/2" pipe` (string, required)
-                        + unit_price: 30.20 (number, required)
+                        + unit_price (Money, required)
 
 + Response 204
 

--- a/src/09-workorders/work-orders.apib
+++ b/src/09-workorders/work-orders.apib
@@ -153,8 +153,15 @@ Add a draft work order.
                + description: `Replacing pipework` (string, optional)
        + materials (array, optional)
            + (object)
-               + product_id: `e2314517-3cab-4aa9-8471-450e73449040` (string, required)
                + quantity: 3 (number, required)
+               + One Of
+                   + Properties
+                       + product_id: `e2314517-3cab-4aa9-8471-450e73449040` (string, required)
+                       + description: `1/2" pipe` (string, optional)
+                       + price: 30.20 (number, optional)
+                   + Properties
+                       + description: `1/2" pipe` (string, required)
+                       + price: 30.20 (number, required)
 
 + Response 201 (application/json)
 
@@ -191,8 +198,15 @@ Update a draft work order.
                 + description (string, optional)
         + materials (array, optional)
             + (object)
-                + product_id: `e2314517-3cab-4aa9-8471-450e73449040` (string, required)
                 + quantity: `2.2` (number, required)
+                + One Of
+                    + Properties
+                        + product_id: `e2314517-3cab-4aa9-8471-450e73449040` (string, required)
+                        + description: `1/2" pipe` (string, optional, nullable)
+                        + price: 30.20 (number, optional, nullable)
+                    + Properties
+                        + description: `1/2" pipe` (string, required)
+                        + price: 30.20 (number, required)
 
 + Response 204
 

--- a/src/09-workorders/work-orders.apib
+++ b/src/09-workorders/work-orders.apib
@@ -117,7 +117,7 @@ Get details for a single work order.
                         + type: `product` (string)
                         + id: `e2314517-3cab-4aa9-8471-450e73449040` (string)
                     + quantity: 3 (number)
-                    + description: `1/2" pipe` (string)
+                    + name: `1/2" pipe` (string)
                     + price: 30.20 (number)
             + images (array) - Only included with request parameter `includes=images`.
                 + (object)
@@ -159,10 +159,10 @@ Add a draft work order.
                + One Of
                    + Properties
                        + product_id: `e2314517-3cab-4aa9-8471-450e73449040` (string, required)
-                       + description: `1/2" pipe` (string, optional)
+                       + name: `1/2" pipe` (string, optional)
                        + price: 30.20 (number, optional)
                    + Properties
-                       + description: `1/2" pipe` (string, required)
+                       + name: `1/2" pipe` (string, required)
                        + price: 30.20 (number, required)
 
 + Response 201 (application/json)
@@ -204,10 +204,10 @@ Update a draft work order.
                 + One Of
                     + Properties
                         + product_id: `e2314517-3cab-4aa9-8471-450e73449040` (string, required)
-                        + description: `1/2" pipe` (string, optional, nullable)
+                        + name: `1/2" pipe` (string, optional, nullable)
                         + price: 30.20 (number, optional, nullable)
                     + Properties
-                        + description: `1/2" pipe` (string, required)
+                        + name: `1/2" pipe` (string, required)
                         + price: 30.20 (number, required)
 
 + Response 204


### PR DESCRIPTION
We either require a product ID *or* name and price. Either way the name and price can be passed as well as of now.

This is required because in the web version you could already draft a WorkOrder from a meeting having a material that is not an existing product (thus without ID) plus you can alter its name and price in the same form.

We need to support these scenarios in the API and mobile app.