### PR TITLE
Makefile Reorder/Remove/Refactor Tasks 

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -8,7 +8,7 @@ node_modules: package.json
 lint: node_modules
 	docker run -it --init --rm -v $(PWD):/code -w /code node:9 npm run lint
 
-build: src node_modules
+build: src node_modules lint
 	docker run -it --init --rm -v $(PWD):/code -w /code node:9 npm run build
 
 preview: build

--- a/Makefile
+++ b/Makefile
@@ -1,18 +1,16 @@
 PWD = $(shell pwd)
 
-all: build lint
+build: src node_modules lint
+	docker run -it --init --rm -v $(PWD):/code -w /code node:9 npm run build
+
+preview: build
+	docker run -it --init --rm -v $(PWD):/code -w /code apiaryio/client preview --path=/code/apiary.apib --output=/code/apiary.html
 
 node_modules: package.json
 	docker run -it --init --rm -v $(PWD):/code -w /code node:9 npm install
 
 lint: node_modules
 	docker run -it --init --rm -v $(PWD):/code -w /code node:9 npm run lint
-
-build: src node_modules lint
-	docker run -it --init --rm -v $(PWD):/code -w /code node:9 npm run build
-
-preview: build
-	docker run -it --init --rm -v $(PWD):/code -w /code apiaryio/client preview --path=/code/apiary.apib --output=/code/apiary.html
 
 watch: node_modules
 	docker run -it --init --rm -v $(PWD):/code -w /code node:9 npm run watch


### PR DESCRIPTION
This may be a particular preference of mine but, if someone forgets to make the lint it will fail in the CI so why not make that a prerequired tasks locally? 

### Changed
- `lint` is now a required task to build
- `build` task is now the default task for make command

### Removed
- `all` task

**Note:**
This change doesn't go against the CONTRIBUTING file because the
default command behavior still stands with the additional improvement of
linting before building or previewing.