### PR TITLE
Section should have been optional in invoices.update

### DIFF
--- a/apiary.apib
+++ b/apiary.apib
@@ -2409,7 +2409,7 @@ Update an invoice.
         + purchase_order_number: `000023` (string, optional)
         + grouped_lines (array, optional)
             + (object)
-                + section (object, required)
+                + section (object, optional)
                     + title (string, required)
                 + line_items (array, required)
                     + (object)

--- a/src/05-invoicing/invoices.apib
+++ b/src/05-invoicing/invoices.apib
@@ -303,7 +303,7 @@ Update an invoice.
         + purchase_order_number: `000023` (string, optional)
         + grouped_lines (array, optional)
             + (object)
-                + section (object, required)
+                + section (object, optional)
                     + title (string, required)
                 + line_items (array, required)
                     + (object)


### PR DESCRIPTION
### Fixed
- Section has always been optional in `/invoices.update`. It was incorrectly documented