### PR TITLE
work order materials: add purchase price

### DIFF
--- a/apiary.apib
+++ b/apiary.apib
@@ -3691,6 +3691,7 @@ Get details for a single work order.
                     + quantity: 3 (number)
                     + name: `1/2" pipe` (string)
                     + unit_price (Money)
+                    + purchase_price (Money, nullable)
             + custom_fields (array[CustomField])
             + images (array) - Only included with request parameter `includes=images`.
                 + (object)
@@ -3730,6 +3731,7 @@ Add a draft work order.
        + materials (array, optional)
            + (object)
                + quantity: 3 (number, required)
+               + purchase_price (Money, optional)
                + One Of
                    + Properties
                        + product_id: `e2314517-3cab-4aa9-8471-450e73449040` (string, required)
@@ -3777,6 +3779,7 @@ Update a draft work order.
         + materials (array, optional)
             + (object)
                 + quantity: `2.2` (number, required)
+                + purchase_price (Money, optional)
                 + One Of
                     + Properties
                         + product_id: `e2314517-3cab-4aa9-8471-450e73449040` (string, required)

--- a/apiary.apib
+++ b/apiary.apib
@@ -3842,6 +3842,7 @@ Send a finalized work order to the customer.
 
     + Attributes (object)
         + id: `4afb0a9c-91c6-49ed-a2e5-ce7c1e3a87fb` (string, required)
+        + mail_template_id: `1a57404ce-f2bf-4fe5-80a4-6113fef4dcf2` (string, optional)
 
 + Response 204
 

--- a/src/09-workorders/work-orders.apib
+++ b/src/09-workorders/work-orders.apib
@@ -281,6 +281,7 @@ Send a finalized work order to the customer.
 
     + Attributes (object)
         + id: `4afb0a9c-91c6-49ed-a2e5-ce7c1e3a87fb` (string, required)
+        + mail_template_id: `1a57404ce-f2bf-4fe5-80a4-6113fef4dcf2` (string, optional)
 
 + Response 204
 

--- a/src/09-workorders/work-orders.apib
+++ b/src/09-workorders/work-orders.apib
@@ -169,6 +169,7 @@ Add a draft work order.
        + materials (array, optional)
            + (object)
                + quantity: 3 (number, required)
+               + purchase_price (Money, optional)
                + One Of
                    + Properties
                        + product_id: `e2314517-3cab-4aa9-8471-450e73449040` (string, required)
@@ -216,6 +217,7 @@ Update a draft work order.
         + materials (array, optional)
             + (object)
                 + quantity: `2.2` (number, required)
+                + purchase_price (Money, optional)
                 + One Of
                     + Properties
                         + product_id: `e2314517-3cab-4aa9-8471-450e73449040` (string, required)

--- a/src/09-workorders/work-orders.apib
+++ b/src/09-workorders/work-orders.apib
@@ -129,6 +129,7 @@ Get details for a single work order.
                     + quantity: 3 (number)
                     + name: `1/2" pipe` (string)
                     + unit_price (Money)
+                    + purchase_price (Money, nullable)
             + custom_fields (array[CustomField])
             + images (array) - Only included with request parameter `includes=images`.
                 + (object)


### PR DESCRIPTION
This can be manually passed to:

* overwrite the purchase price when adding a product as work order material
* set a purchase price when adding a material without a product attached (a one-time product)