### PR TITLE
Fix paragraphs for changes regarding invoiceability of time trackings

### DIFF
--- a/apiary.apib
+++ b/apiary.apib
@@ -415,13 +415,14 @@ We list all backwards-compatible additions here. These are currently available i
 - We now also return the `invoicing_method` of a milestone. Both in `milestones.list` and `milestones.info`.
 
 - We now expose the invoiceability of time trackings and running timers. You can now use the `invoiceable` property on the following endpoints:
-  - `timeTracking.list`  
-  - `timeTracking.info`  
-  - `timeTracking.add`  
-  - `timeTracking.update`  
-  - `timers.current`  
-  - `timers.start`  
-  - `timers.update`  
+  - `timeTracking.list`
+  - `timeTracking.info`
+  - `timeTracking.add`
+  - `timeTracking.update`
+  - `timers.current`
+  - `timers.start`
+  - `timers.update`
+
   We also return an `invoiceable` preference in the `users.me` endpoint that exposes whether a user prefers to track time by default as invoiceable or not.
 
 - We've added a `national_identification_number` property on contacts.

--- a/src/changes-backwards-compatible.apib
+++ b/src/changes-backwards-compatible.apib
@@ -50,13 +50,14 @@ We list all backwards-compatible additions here. These are currently available i
 - We now also return the `invoicing_method` of a milestone. Both in `milestones.list` and `milestones.info`.
 
 - We now expose the invoiceability of time trackings and running timers. You can now use the `invoiceable` property on the following endpoints:
-  - `timeTracking.list`  
-  - `timeTracking.info`  
-  - `timeTracking.add`  
-  - `timeTracking.update`  
-  - `timers.current`  
-  - `timers.start`  
-  - `timers.update`  
+  - `timeTracking.list`
+  - `timeTracking.info`
+  - `timeTracking.add`
+  - `timeTracking.update`
+  - `timers.current`
+  - `timers.start`
+  - `timers.update`
+
   We also return an `invoiceable` preference in the `users.me` endpoint that exposes whether a user prefers to track time by default as invoiceable or not.
 
 - We've added a `national_identification_number` property on contacts.


### PR DESCRIPTION
The final sentence was added to the list item of the last endpoint, instead of being a paragraph of its own.