### PR TITLE
Remove due_at in favour of due_on for Tasks

### DIFF
--- a/apiary.apib
+++ b/apiary.apib
@@ -431,6 +431,12 @@ We list all backwards-incompatible changes here. As described above, new additio
 
 - We renamed the `context` field for work orders on customFieldDefinitions from `werkbonnen` to `work_orders`
 
+- The property `due_at` was removed in favour of `due_on`. Additionally, `due_on` is a date with format `YYYY-MM-DD`, instead of a ISO8601 datetime. These changes affect the following endpoints:
+  - `tasks.info`
+  - `tasks.list`
+  - `tasks.create`
+  - `tasks.update`
+
 #### 2019-03-13
 
 - The property `tax` has been changed. Instead of giving you the `rate` of the tax it now shows the `id` and the `type` of the tax. This has been changed on the following endpoints:
@@ -3246,13 +3252,13 @@ Get a list of tasks.
             + (object)
                 + field (enum[string], required)
                     + Members
-                        + due_at
+                        + due_on
                 + order (enum[string], optional)
                     + Members
                         + asc
             + Default
                 + (object)
-                    + field: `due_at`
+                    + field: `due_on`
                     + order: `asc`
 
 + Response 200 (application/json)
@@ -3264,7 +3270,7 @@ Get a list of tasks.
                 + description (string)
                 + completed: false (boolean)
                 + completed_at: `2016-02-04T16:44:33+00:00` (string)
-                + due_at: `2016-02-04T16:44:33+00:00` (string)
+                + due_on: `2016-02-04` (string)
                 + estimated_duration (object)
                     + unit: `min` (enum[string])
                         + Members
@@ -3297,7 +3303,7 @@ Get information about a task.
             + description (string)
             + completed: false (boolean)
             + completed_at: `2016-02-04T16:44:33+00:00` (string)
-            + due_at: `2016-02-04T16:44:33+00:00` (string)
+            + due_on: `2016-02-04` (string)
             + estimated_duration (object)
                 + unit: `min` (enum[string])
                     + Members
@@ -3321,7 +3327,7 @@ Create a new task.
 
     + Attributes (object)
         + description (string, required)
-        + due_at: `2016-02-04T16:44:33+00:00` (string, required)
+        + due_on: `2016-02-04` (string, required)
         + work_type_id: `32665afd-1818-0ed3-9e18-a603a3a21b95` (string, required)
         + estimated_duration (object, optional)
             + unit: `min` (enum[string], required)
@@ -3351,7 +3357,7 @@ Update a task.
     + Attributes (object)
         + id: `00ed6266-a5bd-4aac-a292-2582017b6400` (string, required)
         + description (string, optional)
-        + due_at: `2016-02-04T16:44:33+00:00` (string, optional)
+        + due_on: `2016-02-04` (string, optional)
         + work_type_id: `32665afd-1818-0ed3-9e18-a603a3a21b95` (string, optional)
         + estimated_duration (object, optional)
             + unit: `min` (enum[string], required)

--- a/src/08-tasks/tasks.apib
+++ b/src/08-tasks/tasks.apib
@@ -16,13 +16,13 @@ Get a list of tasks.
             + (object)
                 + field (enum[string], required)
                     + Members
-                        + due_at
+                        + due_on
                 + order (enum[string], optional)
                     + Members
                         + asc
             + Default
                 + (object)
-                    + field: `due_at`
+                    + field: `due_on`
                     + order: `asc`
 
 + Response 200 (application/json)
@@ -34,7 +34,7 @@ Get a list of tasks.
                 + description (string)
                 + completed: false (boolean)
                 + completed_at: `2016-02-04T16:44:33+00:00` (string)
-                + due_at: `2016-02-04T16:44:33+00:00` (string)
+                + due_on: `2016-02-04` (string)
                 + estimated_duration (object)
                     + unit: `min` (enum[string])
                         + Members
@@ -67,7 +67,7 @@ Get information about a task.
             + description (string)
             + completed: false (boolean)
             + completed_at: `2016-02-04T16:44:33+00:00` (string)
-            + due_at: `2016-02-04T16:44:33+00:00` (string)
+            + due_on: `2016-02-04` (string)
             + estimated_duration (object)
                 + unit: `min` (enum[string])
                     + Members
@@ -91,7 +91,7 @@ Create a new task.
 
     + Attributes (object)
         + description (string, required)
-        + due_at: `2016-02-04T16:44:33+00:00` (string, required)
+        + due_on: `2016-02-04` (string, required)
         + work_type_id: `32665afd-1818-0ed3-9e18-a603a3a21b95` (string, required)
         + estimated_duration (object, optional)
             + unit: `min` (enum[string], required)
@@ -121,7 +121,7 @@ Update a task.
     + Attributes (object)
         + id: `00ed6266-a5bd-4aac-a292-2582017b6400` (string, required)
         + description (string, optional)
-        + due_at: `2016-02-04T16:44:33+00:00` (string, optional)
+        + due_on: `2016-02-04` (string, optional)
         + work_type_id: `32665afd-1818-0ed3-9e18-a603a3a21b95` (string, optional)
         + estimated_duration (object, optional)
             + unit: `min` (enum[string], required)

--- a/src/changes-backwards-incompatible.apib
+++ b/src/changes-backwards-incompatible.apib
@@ -7,6 +7,12 @@ We list all backwards-incompatible changes here. As described above, new additio
 
 - We renamed the `context` field for work orders on customFieldDefinitions from `werkbonnen` to `work_orders`
 
+- The property `due_at` was removed in favour of `due_on`. Additionally, `due_on` is a date with format `YYYY-MM-DD`, instead of a ISO8601 datetime. These changes affect the following endpoints:
+  - `tasks.info`
+  - `tasks.list`
+  - `tasks.create`
+  - `tasks.update`
+
 #### 2019-03-13
 
 - The property `tax` has been changed. Instead of giving you the `rate` of the tax it now shows the `id` and the `type` of the tax. This has been changed on the following endpoints:


### PR DESCRIPTION
Tasks currently have a `due_at` field. However, this should be called `due_on`, since Tasks have a due date, not a due datetime. This is a BC break so this PR is based on the 2019-07-03 branch.