### PR TITLE
[CAL-1492] Add schedule task endpoint

### DIFF
--- a/apiary.apib
+++ b/apiary.apib
@@ -3476,7 +3476,7 @@ Delete a task.
 
 ### tasks.schedule [POST /tasks.schedule]
 
-Schedule a task.
+Schedule a task in your calendar.
 
 + Request (application/json)
 

--- a/apiary.apib
+++ b/apiary.apib
@@ -371,6 +371,8 @@ We list all backwards-compatible additions here. These are currently available i
 
 #### Latest
 
+- We added a `tasks.schedule` endpoint.
+
 - `tasks.info` and `tasks.list` now return information about the customer.
 
 - We added `customer` parameter to `tasks.create` and `tasks.update`.
@@ -3471,6 +3473,24 @@ Delete a task.
         + id: `5f0afd8a-8a40-48a4-bbe6-7d0e9c61bb6d` (string, required)
 
 + Response 204
+
+### tasks.schedule [POST /tasks.schedule]
+
+Schedule a task.
+
++ Request (application/json)
+
+    + Attributes (object)
+        + id: `7c70c54e-6e50-4e6a-b5fd-80234eb535cf` (string, required)
+        + starts_at: `2016-02-04T16:00:00+00:00` (string, required)
+        + ends_at: `2016-02-04T18:00:00+00:00` (string, required)
+        
++ Response 201 (application/json)
+
+    + Attributes (object)
+        + data (object)
+            + type: `event` (string)
+            + id: `d7d2d100-d440-46c2-a4a3-177ad4b2a860` (string)
 
 # Group Time Tracking
 

--- a/src/08-tasks/tasks.apib
+++ b/src/08-tasks/tasks.apib
@@ -190,7 +190,7 @@ Delete a task.
 
 ### tasks.schedule [POST /tasks.schedule]
 
-Schedule a task.
+Schedule a task in your calendar.
 
 + Request (application/json)
 

--- a/src/08-tasks/tasks.apib
+++ b/src/08-tasks/tasks.apib
@@ -187,3 +187,21 @@ Delete a task.
         + id: `5f0afd8a-8a40-48a4-bbe6-7d0e9c61bb6d` (string, required)
 
 + Response 204
+
+### tasks.schedule [POST /tasks.schedule]
+
+Schedule a task.
+
++ Request (application/json)
+
+    + Attributes (object)
+        + id: `7c70c54e-6e50-4e6a-b5fd-80234eb535cf` (string, required)
+        + starts_at: `2016-02-04T16:00:00+00:00` (string, required)
+        + ends_at: `2016-02-04T18:00:00+00:00` (string, required)
+        
++ Response 201 (application/json)
+
+    + Attributes (object)
+        + data (object)
+            + type: `event` (string)
+            + id: `d7d2d100-d440-46c2-a4a3-177ad4b2a860` (string)

--- a/src/changes-backwards-compatible.apib
+++ b/src/changes-backwards-compatible.apib
@@ -6,6 +6,8 @@ We list all backwards-compatible additions here. These are currently available i
 
 #### Latest
 
+- We added a `tasks.schedule` endpoint.
+
 - `tasks.info` and `tasks.list` now return information about the customer.
 
 - We added `customer` parameter to `tasks.create` and `tasks.update`.


### PR DESCRIPTION
We would like to introduce tasks.schedule on the Tasks API in order to be able to create an event linked to a task (schedule task).