### PR TITLE
[Cal-1492] Add task_id filter to events.list

### DIFF
--- a/apiary.apib
+++ b/apiary.apib
@@ -370,6 +370,8 @@ We list all backwards-compatible additions here. These are currently available i
 
 #### Latest
 
+- A `task_id` filter has been added to `/events.list`.
+
 - We added `sent` as a boolean to `invoices.info` and `invoices.list`
 - We added an optional filter on `ids` to `invoices.list`.
 - We added `creditNote.booked` and `product.added` to the available webhooks list.
@@ -1917,6 +1919,7 @@ Get a list of calendar events.
                         + contact
                         + company
                 + id: `2659dc4d-444b-4ced-b51c-b87591f604d7` (string, required)
+            + task_id: `5309c8c9-e313-47b0-90ba-6850c3dc3e33` (string, optional)
         + page (Page, optional)
         + sort (array, optional)
             + (object)

--- a/src/04-calendar/events.apib
+++ b/src/04-calendar/events.apib
@@ -29,6 +29,7 @@ Get a list of calendar events.
                         + contact
                         + company
                 + id: `2659dc4d-444b-4ced-b51c-b87591f604d7` (string, required)
+            + task_id: `5309c8c9-e313-47b0-90ba-6850c3dc3e33` (string, optional)
         + page (Page, optional)
         + sort (array, optional)
             + (object)

--- a/src/changes-backwards-compatible.apib
+++ b/src/changes-backwards-compatible.apib
@@ -6,6 +6,8 @@ We list all backwards-compatible additions here. These are currently available i
 
 #### Latest
 
+- A `task_id` filter has been added to `/events.list`.
+
 - We added `sent` as a boolean to `invoices.info` and `invoices.list`
 - We added an optional filter on `ids` to `invoices.list`.
 - We added `creditNote.booked` and `product.added` to the available webhooks list.


### PR DESCRIPTION
Implementation: teamleadercrm/core#10300

task_id filter was added to /events.list

Recreated, based on 2019-07-03 branch.