### PR TITLE
Add time to the workOrders.list endpoint

### DIFF
--- a/apiary.apib
+++ b/apiary.apib
@@ -3788,7 +3788,7 @@ Get a list of work orders.
                 + location (Address, nullable)
                 + distance (Distance, nullable)
                 + signed: false (boolean)
-                + time (array)
+                + time (array) - Only included with request parameter `includes=time`.
                     + (object)
                         + users (array)
                             + (object)

--- a/apiary.apib
+++ b/apiary.apib
@@ -3788,6 +3788,15 @@ Get a list of work orders.
                 + location (Address, nullable)
                 + distance (Distance, nullable)
                 + signed: false (boolean)
+                + time (array)
+                    + (object)
+                        + users (array)
+                            + (object)
+                                + type: `user` (string)
+                                + id: `4ec55a8c-2d80-472a-a9c2-5ff5ee7eac6a` (string)
+                        + started_at: `2019-02-27T10:01:49+00:00` (string)
+                        + duration: 3600 (number) - In seconds
+                        + description: `Replacing pipework` (string)
                 + created_at: `2019-05-09T11:25:11+00:00` (string)
                 + updated_at: `2019-05-09T11:30:58+00:00` (string)
 

--- a/src/09-workorders/work-orders.apib
+++ b/src/09-workorders/work-orders.apib
@@ -68,7 +68,7 @@ Get a list of work orders.
                 + location (Address, nullable)
                 + distance (Distance, nullable)
                 + signed: false (boolean)
-                + time (array)
+                + time (array) - Only included with request parameter `includes=time`.
                     + (object)
                         + users (array)
                             + (object)

--- a/src/09-workorders/work-orders.apib
+++ b/src/09-workorders/work-orders.apib
@@ -68,6 +68,15 @@ Get a list of work orders.
                 + location (Address, nullable)
                 + distance (Distance, nullable)
                 + signed: false (boolean)
+                + time (array)
+                    + (object)
+                        + users (array)
+                            + (object)
+                                + type: `user` (string)
+                                + id: `4ec55a8c-2d80-472a-a9c2-5ff5ee7eac6a` (string)
+                        + started_at: `2019-02-27T10:01:49+00:00` (string)
+                        + duration: 3600 (number) - In seconds
+                        + description: `Replacing pipework` (string)
                 + created_at: `2019-05-09T11:25:11+00:00` (string)
                 + updated_at: `2019-05-09T11:30:58+00:00` (string)
 


### PR DESCRIPTION
We'll want to display time in work orders overviews (f.e. in the mobile
app, but might be useful for other integrations too). Let's thus include
it in the workOrders.list endpoint.