### PR TITLE
Remove non-existing invoicing email address for contacts

### DIFF
--- a/apiary.apib
+++ b/apiary.apib
@@ -949,7 +949,6 @@ Get a list of contacts.
                         + type: `primary` (enum[string])
                             + Members
                                 + primary
-                                + invoicing
                         + email: `info@piedpiper.eu` (string)
                 + telephones (array[Telephone])
                 + website: `https://piedpiper.com` (string)
@@ -993,7 +992,6 @@ Get details for a single contact.
                     + type: `primary` (enum[string])
                         + Members
                             + primary
-                            + invoicing
                     + email: `info@piedpiper.eu` (string)
             + telephones (array[Telephone])
             + website: `https://piedpiper.com` (string)
@@ -1047,7 +1045,6 @@ Add a new contact.
                 + type: `primary` (enum[string], required)
                     + Members
                         + primary
-                        + invoicing
                 + email: `info@piedpiper.eu` (string, required)
         + salutation: `Mr` (string, optional)
         + telephones (array[Telephone], optional)
@@ -1098,7 +1095,6 @@ Update a contact.
                 + type: `primary` (enum[string], required)
                     + Members
                         + primary
-                        + invoicing
                 + email: `info@piedpiper.eu` (string, required, nullable)
         + telephones (array[Telephone], optional, nullable)
         + website: `http://example.com` (string, optional, nullable)

--- a/src/02-crm/contacts.apib
+++ b/src/02-crm/contacts.apib
@@ -53,7 +53,6 @@ Get a list of contacts.
                         + type: `primary` (enum[string])
                             + Members
                                 + primary
-                                + invoicing
                         + email: `info@piedpiper.eu` (string)
                 + telephones (array[Telephone])
                 + website: `https://piedpiper.com` (string)
@@ -97,7 +96,6 @@ Get details for a single contact.
                     + type: `primary` (enum[string])
                         + Members
                             + primary
-                            + invoicing
                     + email: `info@piedpiper.eu` (string)
             + telephones (array[Telephone])
             + website: `https://piedpiper.com` (string)
@@ -151,7 +149,6 @@ Add a new contact.
                 + type: `primary` (enum[string], required)
                     + Members
                         + primary
-                        + invoicing
                 + email: `info@piedpiper.eu` (string, required)
         + salutation: `Mr` (string, optional)
         + telephones (array[Telephone], optional)
@@ -202,7 +199,6 @@ Update a contact.
                 + type: `primary` (enum[string], required)
                     + Members
                         + primary
-                        + invoicing
                 + email: `info@piedpiper.eu` (string, required, nullable)
         + telephones (array[Telephone], optional, nullable)
         + website: `http://example.com` (string, optional, nullable)


### PR DESCRIPTION
Contacts don't have an invoicing email address in Teamleader, so let's
also remove this from the API documentation.