### PR TITLE
Fix rendering issue with enums

### DIFF
--- a/apiary.apib
+++ b/apiary.apib
@@ -557,10 +557,10 @@ Get a list of departments.
             + ids: `92296ad0-2d61-4179-b174-9f354ca2157f`,`53635682-c382-4fbf-9fd9-9506ca4fbcdd` (array[string], optional)
         + sort (array, optional)
             + (object)
-                + field (enum[string], required)
+                + field (enum, required)
                     + Members
                         + name
-                + order (enum[string], optional)
+                + order (enum, optional)
                     + Members
                         + asc
             + Default
@@ -597,13 +597,13 @@ Get details for a single department.
             + address (Address)
             + emails (array)
                 + (object)
-                    + type: `primary` (enum[string])
+                    + type: `primary` (enum)
                         + Members
                             + primary
                             + invoicing
                     + email: `info@piedpiper.eu` (string)
             + telephones (array[object])
-                + type: `phone` (enum[string], required)
+                + type: `phone` (enum, required)
                     + Members
                         + phone
                         + fax
@@ -636,7 +636,7 @@ Get the current authenticated user.
             + last_name: `Smith` (string)
             + email: `john@teamleader.eu` (string)
             + telephones (array[Telephone])
-            + language: `nl-BE` (enum[string])
+            + language: `nl-BE` (enum)
                 + Members
                     + da-DK
                     + de-DE
@@ -667,16 +667,16 @@ Get a list of all users.
         + filter (object, optional)
             + ids: `cb8da52a-ce89-4bf6-8f7e-8ee6cb85e3b5`,`f8a57a6f-dd1e-41a3-b8d3-428663f1d09e` (array[string], optional)
             + term: `John` (string, optional) - Filters on first name, last name and email
-            + status (array[enum[string]], optional) - Filters on status
+            + status (array[enum], optional) - Filters on status
                 + Members
                     + active - Filters on active users
                     + deactivated - Filters on deactivated users
         + sort (array, optional)
             + (object)
-                + field (enum[string], required)
+                + field (enum, required)
                     + Members
                         + name
-                + order (enum[string], optional)
+                + order (enum, optional)
                     + Members
                         + asc
             + Default
@@ -700,7 +700,7 @@ Get a list of all users.
                 + telephones (array[Telephone])
                 + language: `nl` (string)
                 + function: `Sales` (string)
-                + status: `active` (enum[string])
+                + status: `active` (enum)
                     + Members
                         + active
                         + deactivated
@@ -726,7 +726,7 @@ Get details for a single user.
             + last_name: `Smith` (string)
             + email: `john@teamleader.eu` (string)
             + telephones (array[Telephone])
-            + language: `nl-BE` (enum[string])
+            + language: `nl-BE` (enum)
                 + Members
                     + da-DK
                     + de-DE
@@ -744,7 +744,7 @@ Get details for a single user.
                     + tr-TR
             + function: `Sales` (string)
             + time_zone: `Europe/Brussels` (string)
-            + status: `active` (enum[string])
+            + status: `active` (enum)
                 + Members
                     + active
                     + deactivated
@@ -763,11 +763,11 @@ Get a list of all the definitions of custom fields.
         + page (Page, optional)
         + sort (array, optional)
             + (object)
-                + field (enum[string], required)
+                + field (enum, required)
                     + Members
                         + label
                         + context
-                + order (enum[string], optional)
+                + order (enum, optional)
                     + Members
                         + asc
                         + desc
@@ -782,7 +782,7 @@ Get a list of all the definitions of custom fields.
         + data (array)
             + (object)
                 + id: `74855f4a-2b61-429c-81d8-c79ad3675a76` (string)
-                + context: `contact` (enum[string])
+                + context: `contact` (enum)
                     + Members
                         + contact
                         + company
@@ -793,7 +793,7 @@ Get a list of all the definitions of custom fields.
                         + invoice
                         + subscription
                         + ticket
-                + type (enum[string])
+                + type (enum)
                     + Members
                         + single_line - Single line text
                         + multi_line - Multiline text
@@ -833,7 +833,7 @@ Get info about a specific custom field definition.
     + Attributes (object)
         + data (object)
             + id: `57e851e2-3d3b-4523-82f8-fe77df5a5d6c` (string)
-            + context: `contact` (enum[string])
+            + context: `contact` (enum)
                 + Members
                     + contact
                     + company
@@ -844,7 +844,7 @@ Get info about a specific custom field definition.
                     + invoice
                     + subscription
                     + ticket
-            + type (enum[string])
+            + type (enum)
                 + Members
                     + single_line - Single line text
                     + multi_line - Multiline text
@@ -915,7 +915,7 @@ Get a list of contacts.
     + Attributes (object)
         + filter (object, optional)
             + email (object, optional)
-                + type: `primary` (enum[string], required)
+                + type: `primary` (enum, required)
                     + Members
                          + primary
                 + email: `info@piedpiper.eu` (string, required)
@@ -927,12 +927,12 @@ Get a list of contacts.
         + page (Page, optional)
         + sort (array, optional)
             + (object)
-                + field (enum[string], required)
+                + field (enum, required)
                     + Members
                         + added_at - Sorts on added_at
                         + name - Sorts alphabetically on last_name and first_name
                         + updated_at - Sorts on updated_at
-                + order (enum[string], optional)
+                + order (enum, optional)
                     + Members
                         + asc
                         + desc
@@ -952,14 +952,14 @@ Get a list of contacts.
                 + salutation: `Mr` (string)
                 + emails (array)
                     + (object)
-                        + type: `primary` (enum[string])
+                        + type: `primary` (enum)
                             + Members
                                 + primary
                         + email: `info@piedpiper.eu` (string)
                 + telephones (array[Telephone])
                 + website: `https://piedpiper.com` (string)
                 + primary_address (Address)
-                + gender: `male` (enum[string])
+                + gender: `male` (enum)
                     + Members
                         + male
                         + female
@@ -995,7 +995,7 @@ Get details for a single contact.
             + salutation: `Mr` (string)
             + emails (array)
                 + (object)
-                    + type: `primary` (enum[string])
+                    + type: `primary` (enum)
                         + Members
                             + primary
                     + email: `info@piedpiper.eu` (string)
@@ -1003,14 +1003,14 @@ Get details for a single contact.
             + website: `https://piedpiper.com` (string)
             + addresses (array)
                 + (object)
-                    + type: `invoicing` (enum[string])
+                    + type: `invoicing` (enum)
                         + Members
                             + primary
                             + invoicing
                             + delivery
                             + visiting
                     + address (Addressee) - Primary addresses can not contain an addressee
-            + gender: `male` (enum[string])
+            + gender: `male` (enum)
                 + Members
                     + male
                     + female
@@ -1048,7 +1048,7 @@ Add a new contact.
         + last_name: `Smith` (string, required)
         + emails (array, optional)
             + (object)
-                + type: `primary` (enum[string], required)
+                + type: `primary` (enum, required)
                     + Members
                         + primary
                 + email: `info@piedpiper.eu` (string, required)
@@ -1057,7 +1057,7 @@ Add a new contact.
         + website: `http://example.com` (string, optional)
         + addresses (array, optional)
             + (object)
-                + type: `invoicing` (enum[string], required)
+                + type: `invoicing` (enum, required)
                     + Members
                         + primary
                         + invoicing
@@ -1065,7 +1065,7 @@ Add a new contact.
                         + visiting
                 + address (Addressee, required) - Primary addresses can not contain an addressee
         + language: `en` (string, optional)
-        + gender: `male` (enum[string], optional)
+        + gender: `male` (enum, optional)
             + Members
                 + male
                 + female
@@ -1098,7 +1098,7 @@ Update a contact.
         + salutation: `Mr` (string, optional, nullable)
         + emails (array, optional)
             + (object)
-                + type: `primary` (enum[string], required)
+                + type: `primary` (enum, required)
                     + Members
                         + primary
                 + email: `info@piedpiper.eu` (string, required, nullable)
@@ -1106,7 +1106,7 @@ Update a contact.
         + website: `http://example.com` (string, optional, nullable)
         + addresses (array, optional)
             + (object)
-                + type: `invoicing` (enum[string], required)
+                + type: `invoicing` (enum, required)
                     + Members
                         + primary
                         + invoicing
@@ -1114,7 +1114,7 @@ Update a contact.
                         + visiting
                 + address (Addressee, required) - Primary addresses can not contain an addressee
         + language: `en` (string, optional)
-        + gender: `male` (enum[string], optional, nullable)
+        + gender: `male` (enum, optional, nullable)
             + Members
                 + male
                 + female
@@ -1205,7 +1205,7 @@ Get a list of companies.
     + Attributes (object)
         + filter (object, optional)
             + email (object, optional)
-                + type: `primary` (enum[string], required)
+                + type: `primary` (enum, required)
                     + Members
                          + primary
                 + email: `info@piedpiper.eu` (string, required)
@@ -1216,12 +1216,12 @@ Get a list of companies.
         + page (Page, optional)
         + sort (array, optional)
             + (object)
-                + field (enum[string], required)
+                + field (enum, required)
                     + Members
                         + name
                         + added_at
                         + updated_at
-                + order (enum[string], optional)
+                + order (enum, optional)
                     + Members
                         + asc
                         + desc
@@ -1244,7 +1244,7 @@ Get a list of companies.
                 + national_identification_number: `63326426` (string)
                 + emails (array)
                     + (object)
-                        + type: `primary` (enum[string])
+                        + type: `primary` (enum)
                             + Members
                                 + primary
                                 + invoicing
@@ -1289,7 +1289,7 @@ Get details for a single company.
             + national_identification_number: `63326426` (string)
             + emails (array)
                 + (object)
-                    + type: `primary` (enum[string])
+                    + type: `primary` (enum)
                         + Members
                             + primary
                             + invoicing
@@ -1298,7 +1298,7 @@ Get details for a single company.
             + website: `https://piedpiper.com` (string)
             + addresses (array)
                 + (object)
-                    + type: `invoicing` (enum[string])
+                    + type: `invoicing` (enum)
                         + Members
                             + primary
                             + invoicing
@@ -1336,7 +1336,7 @@ Add a new company.
         + national_identification_number: `63326426` (string, optional)
         + emails (array, optional)
             + (object)
-                + type: `primary` (enum[string], required)
+                + type: `primary` (enum, required)
                     + Members
                         + primary
                         + invoicing
@@ -1345,7 +1345,7 @@ Add a new company.
         + website: `http://example.com` (string, optional)
         + addresses (array, optional)
             + (object)
-                + type: `invoicing` (enum[string], required)
+                + type: `invoicing` (enum, required)
                     + Members
                         + primary
                         + invoicing
@@ -1382,7 +1382,7 @@ Update a company.
         + national_identification_number: `63326426` (string, optional, nullable)
         + emails (array, optional)
             + (object)
-                + type: `primary` (enum[string], required)
+                + type: `primary` (enum, required)
                     + Members
                         + primary
                         + invoicing
@@ -1391,7 +1391,7 @@ Update a company.
         + website: `http://example.com` (string, optional)
         + addresses (array, optional)
             + (object)
-                + type: `invoicing` (enum[string], required)
+                + type: `invoicing` (enum, required)
                     + Members
                         + primary
                         + invoicing
@@ -1478,10 +1478,10 @@ Get a list of tags.
         + page (Page, optional)
         + sort (array, optional)
             + (object)
-                + field (enum[string], required)
+                + field (enum, required)
                     + Members
                         + tag
-                + order (enum[string], optional)
+                + order (enum, optional)
                     + Members
                         + asc
             + Default
@@ -1537,7 +1537,7 @@ Get a list of deals.
             + ids: `3f507137-e599-41d4-8625-0e2adba0be4c`,`ae97f6d3-0bb4-43d3-b13d-f06069d07e98` (array[string], optional)
             + term: `Interesting deal` (string, optional) - Filters on the title, reference and customer's name
             + customer (object, optional)
-                + type (enum[string], required)
+                + type (enum, required)
                     + Members
                         + company
                         + contact
@@ -1548,10 +1548,10 @@ Get a list of deals.
         + page (Page, optional)
         + sort (array, optional)
             + (object)
-                + field (enum[string], required)
+                + field (enum, required)
                     + Members
                         + created_at
-                + order (enum[string], optional)
+                + order (enum, optional)
                     + Members
                         + desc
             + Default
@@ -1568,7 +1568,7 @@ Get a list of deals.
                 + id: `6e7fe84d-d4b3-4723-abae-9bc082d8f65a` (string)
                 + title: `Interesting deal` (string)
                 + reference: `2017/2` (string)
-                + status: `won` (enum[string])
+                + status: `won` (enum)
                     + Members
                         + new
                         + open
@@ -1576,7 +1576,7 @@ Get a list of deals.
                         + lost
                 + lead (object)
                     + customer (object)
-                        + type: `company` (enum[string])
+                        + type: `company` (enum)
                             + Members
                                 + contact
                                 + company
@@ -1620,14 +1620,14 @@ Get details for a single deal.
             + id: `f6871b06-6513-4750-b5e6-ff3503b5a029` (string)
             + title: `Interesting deal` (string)
             + reference: `2017/2` (string)
-            + status: `won` (enum[string])
+            + status: `won` (enum)
                 + Members
                     + open
                     + won
                     + lost
             + lead (object)
                 + customer (object)
-                    + type: `company` (enum[string])
+                    + type: `company` (enum)
                         + Members
                             + contact
                             + company
@@ -1678,7 +1678,7 @@ Create a new deal for a customer.
     + Attributes (object)
         + lead (object, required)
             + customer (object, required)
-                + type (enum[string], required)
+                + type (enum, required)
                     + Members
                         + contact
                         + company
@@ -1711,7 +1711,7 @@ Update a deal.
         + id: `65a35860-dcca-4850-9fd6-47ff08469e0c` (string, required)
         + lead (object, required)
             + customer (object, required)
-                + type (enum[string], required)
+                + type (enum, required)
                     + Members
                         + contact
                         + company
@@ -1785,10 +1785,10 @@ Get a list of lost reasons for deals.
         + page (Page, optional)
         + sort (array, optional)
             + (object)
-                + field (enum[string], required)
+                + field (enum, required)
                     + Members
                         + name
-                + order (enum[string], optional)
+                + order (enum, optional)
                     + Members
                         + asc
             + Default
@@ -1896,14 +1896,14 @@ Get a quotation
                             + extended_description: `Some more information about this awesome product` (string) - Uses Markdown formatting
                             + unit_price (object)
                                 + Include Money
-                                + tax: `excluding` (enum[string])
+                                + tax: `excluding` (enum)
                                     + Members
                                         + excluding
                             + tax (object)
                                 + type: `taxRate` (string)
                                 + id: `e2314517-3cab-4aa9-8471-450e73449042`
                             + discount (object, nullable)
-                                + type: `percentage` (enum[string])
+                                + type: `percentage` (enum)
                                     + Members
                                         + percentage
                                 + value: 15.00 (number)
@@ -1925,7 +1925,7 @@ Download a quotation in a specific format.
 
     + Attributes (object)
         + id: `d885e5d5-bacb-4607-bde9-abc4a04a901b` (string, required)
-        + format: `pdf` (enum[string], required)
+        + format: `pdf` (enum, required)
             + Members
                 + pdf
 
@@ -1959,12 +1959,12 @@ Get a list of calendar events.
             + starts_before: `2018-01-01T00:00:00+00:00` (string, optional) - End of the period for which to return events
             + term: `coffee` (string, optional) - Searches for a term in title or description
             + attendee (object, optional)
-                + type (enum[string], required)
+                + type (enum, required)
                     + Members
                         + contact
                 + id: `2659dc4d-444b-4ced-b51c-b87591f604d7` (string, required)
             + link (object, optional)
-                + type (enum[string], required)
+                + type (enum, required)
                     + Members
                         + contact
                         + company
@@ -1972,10 +1972,10 @@ Get a list of calendar events.
         + page (Page, optional)
         + sort (array, optional)
             + (object)
-                + field: `starts_at` (enum[string], required)
+                + field: `starts_at` (enum, required)
                     + Members
                         + starts_at
-                + order: `asc` (enum[string], optional)
+                + order: `asc` (enum, optional)
                     + Members
                         + asc
                         + desc
@@ -2006,14 +2006,14 @@ Get a list of calendar events.
                 + location (string)
                 + attendees (array)
                     + (object)
-                        + type: `contact` (enum[string])
+                        + type: `contact` (enum)
                             + Members
                                 + user
                                 + contact
                         + id: `8b3afad7-648d-4b4c-b38b-5726d3222282` (string)
                 + links (array)
                     + (object)
-                        + type (enum[string])
+                        + type (enum)
                             + Members
                                 + company
                                 + contact
@@ -2050,14 +2050,14 @@ Get details for a single calendar event.
             + location (string)
             + attendees (array)
                 + (object)
-                    + type: `contact` (enum[string])
+                    + type: `contact` (enum)
                         + Members
                             + user
                             + contact
                     + id: `8b3afad7-648d-4b4c-b38b-5726d3222282` (string)
             + links (array)
                 + (object)
-                    + type (enum[string])
+                    + type (enum)
                         + Members
                             + company
                             + contact
@@ -2079,14 +2079,14 @@ Create a new calendar event.
         + work_type_id: `b37e2bc7-dea0-4fda-88e9-c092fb65667d` (string, optional)
         + attendees (array, optional)
             + (object)
-                + type: `user` (enum[string], required)
+                + type: `user` (enum, required)
                     + Members
                         + user
                         + contact
                 + id: `6ddd2666-65a0-497f-9f01-54c4343ec1a6` (string, required)
         + links (array, optional)
             + (object)
-                + type: `company` (enum[string], required)
+                + type: `company` (enum, required)
                     + Members
                         + company
                         + contact
@@ -2115,14 +2115,14 @@ Update a calendar event.
         + work_type_id: `b37e2bc7-dea0-4fda-88e9-c092fb65667d` (string, optional)
         + attendees (array, optional)
             + (object)
-                + type: `user` (enum[string], required)
+                + type: `user` (enum, required)
                     + Members
                         + user
                         + contact
                 + id: `6ddd2666-65a0-497f-9f01-54c4343ec1a6` (string, required)
         + links (array, optional)
             + (object)
-                + type: `company` (enum[string], required)
+                + type: `company` (enum, required)
                     + Members
                         + company
                         + contact
@@ -2182,7 +2182,7 @@ Get a list of invoices.
         + filter (object, optional)
             + ids: `cb8da52a-ce89-4bf6-8f7e-8ee6cb85e3b5`,`f8a57a6f-dd1e-41a3-b8d3-428663f1d09e` (array[string], optional)
             + department_id: `080aac72-ff1a-4627-bfe3-146b6eee979c` (string, optional) - The ID of the department you wish to filter on.
-            + status (array[enum[string]], optional) - The statuses you want to filter by.
+            + status (array[enum], optional) - The statuses you want to filter by.
                 + Members
                     + draft
                     + outstanding
@@ -2193,10 +2193,10 @@ Get a list of invoices.
         + page (Page, optional)
         + sort (array, optional)
             + (object)
-                + field (enum[string], required)
+                + field (enum, required)
                     + Members
                         + invoice_number
-                + order (enum[string], optional)
+                + order (enum, optional)
                     + Members
                         + asc
             + Default
@@ -2215,7 +2215,7 @@ Get a list of invoices.
                     + id: `5e90eb0a-b502-4344-aa0f-3b8525af6186` (string)
                 + invoice_number: `2017 / 5` (string, nullable)
                 + invoice_date: `2016-02-04` (string, nullable)
-                + status: `matched` (enum[string])
+                + status: `matched` (enum)
                     + Members
                         + draft
                         + outstanding
@@ -2269,7 +2269,7 @@ Get details for a single invoice.
                 + id: `8f802cba-443b-4c69-800f-5852e967000b` (string)
             + invoice_number: `2017 / 5` (string, nullable)
             + invoice_date: `2016-02-04` (string, nullable)
-            + status: `outstanding` (enum[string])
+            + status: `outstanding` (enum)
                 + Members
                     + draft
                     + outstanding
@@ -2294,7 +2294,7 @@ Get details for a single invoice.
                 + national_identification_number: `123` (string, nullable)
             + discounts (array)
                 + (object)
-                    + type: `percentage` (enum[string])
+                    + type: `percentage` (enum)
                         + Members
                             + percentage
                     + value: 15.00 (number)
@@ -2316,14 +2316,14 @@ Get details for a single invoice.
                             + extended_description: `Some more information about this awesome product` (string, nullable) - Uses Markdown formatting
                             + unit_price (object)
                                 + Include Money
-                                + tax: `excluding` (enum[string])
+                                + tax: `excluding` (enum)
                                     + Members
                                         + excluding
                             + tax (object)
                                 + type: `taxRate` (string)
                                 + id: `e2314517-3cab-4aa9-8471-450e73449042` (string)
                             + discount (object, nullable)
-                                + type: `percentage` (enum[string])
+                                + type: `percentage` (enum)
                                     + Members
                                         + percentage
                                 + value: 15.00 (number)
@@ -2376,7 +2376,7 @@ Download an invoice in a specific format.
 
     + Attributes (object)
         + id: `d885e5d5-bacb-4607-bde9-abc4a04a901b` (string, required)
-        + format: `pdf` (enum[string], required)
+        + format: `pdf` (enum, required)
             + Members
                 + pdf
 
@@ -2396,7 +2396,7 @@ Draft a new invoice.
     + Attributes (object)
         + invoicee (object, required)
             + customer (object, required)
-                + type (enum[string])
+                + type (enum)
                     + Members
                         + contact
                         + company
@@ -2419,14 +2419,14 @@ Draft a new invoice.
                         + extended_description: `Some more information about this awesome product` (string, optional, nullable) - Uses Markdown formatting
                         + unit_price (object)
                             + Include Money
-                            + tax: `excluding` (enum[string], required)
+                            + tax: `excluding` (enum, required)
                                 + Members
                                     + excluding
                         + tax_rate_id: `c0c03f1e-77e3-402c-a713-30ea1c585823` (string, required)
                         + withholding_tax_rate_id: `c0c03f1e-77e3-402c-a713-30ea1c585824` (string, optional)
                         + discount (object, optional)
                             + value: 10 (number, required)
-                            + type (enum[string], required)
+                            + type (enum, required)
                                 + Members
                                     + percentage - Values between 0 and 100
                         + product_category_id: `e2314517-3cab-4aa9-8471-450e73449041` (string, optional)
@@ -2434,7 +2434,7 @@ Draft a new invoice.
         + discounts (array, optional)
             (object)
                 + value: 10 (number, required)
-                + type (enum[string], required)
+                + type (enum, required)
                     + Members
                         + percentage - Values between 0 and 100
                 + description: `winter promotion` (string, required)
@@ -2458,7 +2458,7 @@ Update an invoice.
         + id: `b7023c11-455e-4fa5-bb96-87f37dbc7d07` (string, required)
         + invoicee (object, optional)
             + customer (object, required)
-                + type (enum[string])
+                + type (enum)
                     + Members
                         + contact
                         + company
@@ -2480,14 +2480,14 @@ Update an invoice.
                         + extended_description: `Some more information about this awesome product` (string, optional, nullable) - Uses Markdown formatting
                         + unit_price (object)
                             + Include Money
-                            + tax: `excluding` (enum[string])
+                            + tax: `excluding` (enum)
                                 + Members
                                     + excluding
                         + tax_rate_id: `c0c03f1e-77e3-402c-a713-30ea1c585823` (string, required)
                         + withholding_tax_rate_id: `c0c03f1e-77e3-402c-a713-30ea1c585824` (string, optional)
                         + discount (object, optional)
                             + value: 10 (number, required)
-                            + type (enum[string], required)
+                            + type (enum, required)
                                 + Members
                                     + percentage - Values between 0 and 100
                         + product_category_id: `e2314517-3cab-4aa9-8471-450e73449041` (string, optional)
@@ -2496,7 +2496,7 @@ Update an invoice.
         + discounts (array, optional)
             (object)
                 + value: 10 (number, required)
-                + type (enum[string], required)
+                + type (enum, required)
                     + Members
                         + percentage - Values between 0 and 100
                 + description: `winter promotion` (string, required)
@@ -2593,10 +2593,10 @@ List credit notes
         + page (Page, optional)
         + sort (array, optional)
             + (object)
-                + field (enum[string], required)
+                + field (enum, required)
                     + Members
                         + credit_note_number
-                + order (enum[string], optional)
+                + order (enum, optional)
                     + Members
                         + asc
             + Default
@@ -2615,7 +2615,7 @@ List credit notes
                     + id: `36386b05-936e-4cc0-9523-bd20d797ebf5` (string)
                 + credit_note_number: `2017/5` (string, nullable)
                 + credit_note_date: `2016-02-04` (string, nullable)
-                + status: `booked` (enum[string])
+                + status: `booked` (enum)
                     + Members
                         + booked
                 + invoice (object, nullable)
@@ -2661,7 +2661,7 @@ Get details for a single credit note
                     + id: `36386b05-936e-4cc0-9523-bd20d797ebf5` (string)
                 + credit_note_number: `2017/5` (string, nullable)
                 + credit_note_date: `2016-02-04` (string, nullable)
-                + status: `booked` (enum[string])
+                + status: `booked` (enum)
                     + Members
                         + booked
                 + invoice (object, nullable)
@@ -2703,14 +2703,14 @@ Get details for a single credit note
                                 + extended_description: `Some more information about this awesome product` (string) - Uses Markdown formatting
                                 + unit_price (object)
                                     + Include Money
-                                    + tax: `excluding` (enum[string])
+                                    + tax: `excluding` (enum)
                                         + Members
                                             + excluding
                                 + tax (object)
                                     + type: `taxRate` (string)
                                     + id: `e2314517-3cab-4aa9-8471-450e73449042` (string)
                                 + discount (object, nullable)
-                                    + type: `percentage` (enum[string])
+                                    + type: `percentage` (enum)
                                         + Members
                                             + percentage
                                     + value: `15.00` (number)
@@ -2734,7 +2734,7 @@ Download a credit note in a specific format.
 
     + Attributes (object)
         + id: `d885e5d5-bacb-4607-bde9-abc4a04a901b` (string, required)
-        + format: `pdf` (enum[string], required)
+        + format: `pdf` (enum, required)
             + Members
                 + pdf
 
@@ -2945,12 +2945,12 @@ Get a list of projects.
     + Attributes (object)
         + filter (object, optional)
             + customer (object, optional)
-                + type (enum[string], required)
+                + type (enum, required)
                     + Members
                         + company
                         + contact
                 + id: `ebafa4c5-fa8a-4409-92e5-1b192243372f` (string, required)
-            + status (enum[string], optional)
+            + status (enum, optional)
                 + Members
                     + active
                     + on_hold
@@ -2961,10 +2961,10 @@ Get a list of projects.
         + page (Page, optional)
         + sort (array, optional)
             + (object)
-                + field (enum[string], required)
+                + field (enum, required)
                     + Members
                         + due_on
-                + order (enum[string], optional)
+                + order (enum, optional)
                     + Members
                         + asc
             + Default
@@ -2981,7 +2981,7 @@ Get a list of projects.
                 + reference: `PRO-2` (string)
                 + title: `New company website` (string)
                 + description (string)
-                + status: `active` (enum[string])
+                + status: `active` (enum)
                     + Members
                         + active
                         + on_hold
@@ -3014,14 +3014,14 @@ Get details for a single project.
             + reference: `PRO-1` (string)
             + title: `New company website` (string)
             + description (string)
-            + status: `active` (enum[string])
+            + status: `active` (enum)
                 + Members
                     + active
                     + on_hold
                     + done
                     + cancelled
             + customer (object)
-                + type: `contact` (enum[string])
+                + type: `contact` (enum)
                     + Members
                         + contact
                         + company
@@ -3038,11 +3038,11 @@ Get details for a single project.
             + participants (array)
                 + (object)
                     + participant (object)
-                        + type: `user` (enum[string])
+                        + type: `user` (enum)
                             + Members
                                 + user
                         + id: `b0ef899b-143c-4708-90ce-aecb3350e116` (string)
-                    + role (enum[string])
+                    + role (enum)
                         + Members
                             + decision_maker
                             + member
@@ -3068,13 +3068,13 @@ Create a new project.
                 + participant (object, required)
                     + type: `user` (string, required)
                     + id: `e1240972-6cfc-4549-b49c-edda7568cc48` (string, required)
-                + role (enum[string], optional)
+                + role (enum, optional)
                     + Members
                         + decision_maker
                         + member
                     + Default: `member`
         + customer (object, optional)
-            + type (enum[string], required)
+            + type (enum, required)
                 + Members
                     + contact
                     + company
@@ -3098,7 +3098,7 @@ Update a project.
         + id: `dcc2e8ed-51be-4cb6-9c01-034aedac86fd` (string, required)
         + title: `New company website` (string, required)
         + description (string, required)
-        + status: `active` (enum[string], required)
+        + status: `active` (enum, required)
             + Members
                 + active
                 + on_hold
@@ -3132,7 +3132,7 @@ Add a participant to a project.
         + participant (object, required)
             + type: `user` (string)
             + id: `a1388f3d-6116-4792-ac1c-04657697539e` (string)
-        + role (enum[string], optional)
+        + role (enum, optional)
             + Members
                 + decision_maker
                 + member
@@ -3152,7 +3152,7 @@ Update a participant's role for a project.
         + participant (object, optional)
             + type: `user` (string)
             + id: `5ccbc008-f65e-4192-836c-4d7e21f54052` (string)
-        + role (enum[string], required)
+        + role (enum, required)
             + Members
                 + decision_maker
                 + member
@@ -3175,7 +3175,7 @@ Get a list of project milestones.
         + filter (object, optional)
             + ids: `bbbfe0da-e692-4ee3-9d3d-0716808d6523`,`722e1eb9-53d5-4b8c-9d17-154dcc65c610` (array[string], optional)
             + project_id: `082e6289-30c5-45ad-bcd0-190b02d21e81` (string, optional)
-            + status (enum[string], optional)
+            + status (enum, optional)
                 + Members
                     + open
                     + closed
@@ -3184,10 +3184,10 @@ Get a list of project milestones.
         + page (Page, optional)
         + sort (array, optional)
             + (object)
-                + field (enum[string], required)
+                + field (enum, required)
                     + Members
                         + due_on
-                + order (enum[string], optional)
+                + order (enum, optional)
                     + Members
                         + asc
             + Default
@@ -3209,11 +3209,11 @@ Get a list of project milestones.
                 + responsible_user (object)
                     + type: `user` (string)
                     + id: `e1240972-6cfc-4549-b49c-edda7568cc48` (string)
-                + status: `done` (enum[string])
+                + status: `done` (enum)
                     + Members
                         + open
                         + closed
-                + `invoicing_method`: `time_and_materials` (enum[string])
+                + `invoicing_method`: `time_and_materials` (enum)
                     + Members
                         + time_and_materials
                         + fixed_price
@@ -3241,11 +3241,11 @@ Get details for a single milestone.
             + responsible_user (object)
                 + type: `user` (string)
                 + id: `e1240972-6cfc-4549-b49c-edda7568cc48` (string)
-            + status: `done` (enum[string])
+            + status: `done` (enum)
                 + Members
                     + open
                     + closed
-            + `invoicing_method`: `time_and_materials` (enum[string])
+            + `invoicing_method`: `time_and_materials` (enum)
                 + Members
                     + time_and_materials
                     + fixed_price
@@ -3304,10 +3304,10 @@ Get a list of tasks.
         + page (Page, optional)
         + sort (array, optional)
             + (object)
-                + field (enum[string], required)
+                + field (enum, required)
                     + Members
                         + due_at
-                + order (enum[string], optional)
+                + order (enum, optional)
                     + Members
                         + asc
                         + desc
@@ -3327,7 +3327,7 @@ Get a list of tasks.
                 + completed_at: `2016-02-04T16:44:33+00:00` (string)
                 + due_at: `2016-02-04T16:44:33+00:00` (string)
                 + estimated_duration (object)
-                    + unit (enum[string])
+                    + unit (enum)
                         + Members
                             + min - Minutes
                     + value: `60` (number)
@@ -3335,13 +3335,13 @@ Get a list of tasks.
                     + type: `workType` (string)
                     + id: `32665afd-1818-0ed3-9e18-a603a3a21b95` (string)
                 + assignee (object)
-                    + type: `user` (enum[string])
+                    + type: `user` (enum)
                         + Members
                             + user
                             + team
                     + id: `f29abf48-337d-44b4-aad4-585f5277a456` (string)
                 + customer (object, nullable)
-                    + type: `contact` (enum[string])
+                    + type: `contact` (enum)
                         + Members
                             + contact
                             + company
@@ -3372,7 +3372,7 @@ Get information about a task.
             + completed_at: `2016-02-04T16:44:33+00:00` (string)
             + due_at: `2016-02-04T16:44:33+00:00` (string)
             + estimated_duration (object)
-                + unit (enum[string])
+                + unit (enum)
                     + Members
                         + min - Minutes
                 + value: `60` (number)
@@ -3380,13 +3380,13 @@ Get information about a task.
                 + type: `workType` (string)
                 + id: `32665afd-1818-0ed3-9e18-a603a3a21b95` (string)
             + assignee (object)
-                + type: `user` (enum[string])
+                + type: `user` (enum)
                     + Members
                         + user
                         + team
                 + id: `f29abf48-337d-44b4-aad4-585f5277a456` (string)
             + customer (object, nullable)
-                + type: `contact` (enum[string])
+                + type: `contact` (enum)
                     + Members
                         + contact
                         + company
@@ -3411,18 +3411,18 @@ Create a new task.
         + milestone_id: `32665afd-1818-0ed3-9e18-a603a3a21b95` (string, optional)
         + deal_id: `32665afd-1818-0ed3-9e18-a603a3a21b95` (string, optional)
         + estimated_duration (object, optional)
-            + unit (enum[string], required)
+            + unit (enum, required)
                 + Members
                     + min - Minutes
             + value: `60` (number, required)
         + assignee (object, optional)
-            + type: `user` (enum[string])
+            + type: `user` (enum)
                 + Members
                     + user
                     + team
             + id: `f29abf48-337d-44b4-aad4-585f5277a456` (string)
         + customer (object, optional)
-            + type: `contact` (enum[string])
+            + type: `contact` (enum)
                 + Members
                     + contact
                     + company
@@ -3449,18 +3449,18 @@ Update a task.
         + milestone_id: `32665afd-1818-0ed3-9e18-a603a3a21b95` (string, optional, nullable)
         + deal_id: `32665afd-1818-0ed3-9e18-a603a3a21b95` (string, optional, nullable)
         + estimated_duration (object, optional)
-            + unit (enum[string], required)
+            + unit (enum, required)
                 + Members
                     + min - Minutes
             + value: `60` (number, required)
         + assignee (object, optional)
-            + type: `user` (enum[string])
+            + type: `user` (enum)
                 + Members
                     + user
                     + team
             + id: `f29abf48-337d-44b4-aad4-585f5277a456` (string)
         + customer (object, optional)
-            + type: `contact` (enum[string])
+            + type: `contact` (enum)
                 + Members
                     + contact
                     + company
@@ -3541,10 +3541,10 @@ Get a list of tracked time.
         + page (Page, optional)
         + sort (array, optional)
             + (object)
-                + field (enum[string], required)
+                + field (enum, required)
                     + Members
                         + started_on
-                + order (enum[string], optional)
+                + order (enum, optional)
                     + Members
                         + desc
             + Default
@@ -3570,7 +3570,7 @@ Get a list of tracked time.
                 + duration: 3600 (number) - In seconds
                 + description: `Timer description` (string)
                 + subject (object)
-                    + type: `milestone` (enum[string])
+                    + type: `milestone` (enum)
                         + Members
                             + company
                             + contact
@@ -3607,7 +3607,7 @@ Get information about tracked time.
             + duration: 3600 (number) - In seconds
             + description: `Timer description` (string)
             + subject (object)
-                + type: `milestone` (enum[string])
+                + type: `milestone` (enum)
                     + Members
                         + company
                         + contact
@@ -3637,7 +3637,7 @@ Add tracked time.
                 + ended_at: `2017-04-26T16:02:00+00:00` (string, required)
         + description (string, optional)
         + subject (object, optional)
-            + type: `milestone` (enum[string], required)
+            + type: `milestone` (enum, required)
                 + Members
                     + company
                     + contact
@@ -3670,7 +3670,7 @@ Update tracked time.
                 + duration: 3600 (number, required) - In seconds
         + description (string, optional, nullable)
         + subject (object, optional, nullable)
-            + type: `milestone` (enum[string], required)
+            + type: `milestone` (enum, required)
                 + Members
                     + company
                     + contact
@@ -3733,7 +3733,7 @@ Get the current running timer.
             + started_at: `2017-04-26T10:01:49+00:00` (string)
             + description: `Timer description` (string)
             + subject (object)
-                + type: `milestone` (enum[string])
+                + type: `milestone` (enum)
                     + Members
                         + company
                         + contact
@@ -3755,7 +3755,7 @@ Start a new timer.
         + started_at: `2017-04-26T10:01:49+00:00` (string, optional) - If not provided, current time will be used
         + description (string, optional)
         + subject (object, optional)
-            + type: `milestone` (enum[string], required)
+            + type: `milestone` (enum, required)
                 + Members
                     + company
                     + contact
@@ -3800,7 +3800,7 @@ Update the current timer. Only possible if there is a timer running.
         + started_at: `2017-04-26T10:01:49+00:00` (string, optional)
         + description: `Timer Description` (string, optional, nullable)
         + subject (object, optional, nullable)
-            + type: `milestone` (enum[string], required)
+            + type: `milestone` (enum, required)
                 + Members
                     + company
                     + contact
@@ -3825,7 +3825,7 @@ Add a draft work order.
 
     + Attributes (object)
        + customer (object, required)
-           + type (enum[string], required)
+           + type (enum, required)
                + Members
                    + contact
                    + company
@@ -3862,7 +3862,7 @@ Translates an ID from the deprecated API into a new UUID.
 + Request (application/json)
 
     + Attributes (object)
-        + type: `contact` (enum[string])
+        + type: `contact` (enum)
             + Members
                 + account
                 + user
@@ -3887,7 +3887,7 @@ Translates an ID from the deprecated API into a new UUID.
 
     + Attributes
         + data (object)
-            + type: `contact` (enum[string])
+            + type: `contact` (enum)
                 + Members
                     + account
                     + user
@@ -3931,7 +3931,7 @@ Translates "meeting", "call" and "task" into their respective activity type UUID
 + Request (application/json)
 
     + Attributes (object)
-        + type: `meeting` (enum[string])
+        + type: `meeting` (enum)
             + Members
                 + meeting
                 + call
@@ -3980,7 +3980,7 @@ Unregister a webhook.
 # Data Structures
 
 ## Telephone (object)
-+ type: `phone` (enum[string], required)
++ type: `phone` (enum, required)
     + Members
         + phone
         + mobile
@@ -3988,7 +3988,7 @@ Unregister a webhook.
 + number: `092980615` (string, required)
 
 ## CompanyTelephone (object)
-+ type: `phone` (enum[string], required)
++ type: `phone` (enum, required)
     + Members
         + phone
         + fax
@@ -4006,7 +4006,7 @@ Unregister a webhook.
 
 ## Money (object)
 + amount: `123.30` (number, required)
-+ currency: `EUR` (enum[string], required)
++ currency: `EUR` (enum, required)
     + Members
         + BAM
         + CAD
@@ -4043,7 +4043,7 @@ Unregister a webhook.
 + number: `2` (number)
 
 ## PaymentTerm  (object)
-+ type (enum[string])
++ type (enum)
     + Members
         + cash - Direct payment, often cash
         + end_of_month - End of the month of Xth day after the invoice date
@@ -4060,7 +4060,7 @@ Unregister a webhook.
     + value: `foo`,`bar` (array[string]) - For multiple selection fields
     + value: true (boolean) - For Yes/No fields
     + value (object) - For related Teamleader objects
-        + type: `company` (enum[string])
+        + type: `company` (enum)
             + Members
                 + company
                 + contact
@@ -4076,7 +4076,7 @@ Unregister a webhook.
     + value: `foo`,`bar` (array[string]) - For multiple selection fields
     + value: true (boolean) - For Yes/No fields
     + value (object) - For related Teamleader objects
-        + type: `company` (enum[string])
+        + type: `company` (enum)
             + Members
                 + company
                 + contact
@@ -4086,7 +4086,7 @@ Unregister a webhook.
 
 ## WebHook (object)
 + url: `https://example.com` (string, required) - Your webhook URL
-+ types (array[enum[string]], required) - Array of event types that fire the webhook
++ types (array[enum], required) - Array of event types that fire the webhook
     + Members
         + account.deactivated
         + account.deleted

--- a/src/01-general/custom-fields.apib
+++ b/src/01-general/custom-fields.apib
@@ -12,11 +12,11 @@ Get a list of all the definitions of custom fields.
         + page (Page, optional)
         + sort (array, optional)
             + (object)
-                + field (enum[string], required)
+                + field (enum, required)
                     + Members
                         + label
                         + context
-                + order (enum[string], optional)
+                + order (enum, optional)
                     + Members
                         + asc
                         + desc
@@ -31,7 +31,7 @@ Get a list of all the definitions of custom fields.
         + data (array)
             + (object)
                 + id: `74855f4a-2b61-429c-81d8-c79ad3675a76` (string)
-                + context: `contact` (enum[string])
+                + context: `contact` (enum)
                     + Members
                         + contact
                         + company
@@ -42,7 +42,7 @@ Get a list of all the definitions of custom fields.
                         + invoice
                         + subscription
                         + ticket
-                + type (enum[string])
+                + type (enum)
                     + Members
                         + single_line - Single line text
                         + multi_line - Multiline text
@@ -82,7 +82,7 @@ Get info about a specific custom field definition.
     + Attributes (object)
         + data (object)
             + id: `57e851e2-3d3b-4523-82f8-fe77df5a5d6c` (string)
-            + context: `contact` (enum[string])
+            + context: `contact` (enum)
                 + Members
                     + contact
                     + company
@@ -93,7 +93,7 @@ Get info about a specific custom field definition.
                     + invoice
                     + subscription
                     + ticket
-            + type (enum[string])
+            + type (enum)
                 + Members
                     + single_line - Single line text
                     + multi_line - Multiline text

--- a/src/01-general/departments.apib
+++ b/src/01-general/departments.apib
@@ -15,10 +15,10 @@ Get a list of departments.
             + ids: `92296ad0-2d61-4179-b174-9f354ca2157f`,`53635682-c382-4fbf-9fd9-9506ca4fbcdd` (array[string], optional)
         + sort (array, optional)
             + (object)
-                + field (enum[string], required)
+                + field (enum, required)
                     + Members
                         + name
-                + order (enum[string], optional)
+                + order (enum, optional)
                     + Members
                         + asc
             + Default
@@ -55,13 +55,13 @@ Get details for a single department.
             + address (Address)
             + emails (array)
                 + (object)
-                    + type: `primary` (enum[string])
+                    + type: `primary` (enum)
                         + Members
                             + primary
                             + invoicing
                     + email: `info@piedpiper.eu` (string)
             + telephones (array[object])
-                + type: `phone` (enum[string], required)
+                + type: `phone` (enum, required)
                     + Members
                         + phone
                         + fax

--- a/src/01-general/users.apib
+++ b/src/01-general/users.apib
@@ -20,7 +20,7 @@ Get the current authenticated user.
             + last_name: `Smith` (string)
             + email: `john@teamleader.eu` (string)
             + telephones (array[Telephone])
-            + language: `nl-BE` (enum[string])
+            + language: `nl-BE` (enum)
                 + Members
                     + da-DK
                     + de-DE
@@ -51,16 +51,16 @@ Get a list of all users.
         + filter (object, optional)
             + ids: `cb8da52a-ce89-4bf6-8f7e-8ee6cb85e3b5`,`f8a57a6f-dd1e-41a3-b8d3-428663f1d09e` (array[string], optional)
             + term: `John` (string, optional) - Filters on first name, last name and email
-            + status (array[enum[string]], optional) - Filters on status
+            + status (array[enum], optional) - Filters on status
                 + Members
                     + active - Filters on active users
                     + deactivated - Filters on deactivated users
         + sort (array, optional)
             + (object)
-                + field (enum[string], required)
+                + field (enum, required)
                     + Members
                         + name
-                + order (enum[string], optional)
+                + order (enum, optional)
                     + Members
                         + asc
             + Default
@@ -84,7 +84,7 @@ Get a list of all users.
                 + telephones (array[Telephone])
                 + language: `nl` (string)
                 + function: `Sales` (string)
-                + status: `active` (enum[string])
+                + status: `active` (enum)
                     + Members
                         + active
                         + deactivated
@@ -110,7 +110,7 @@ Get details for a single user.
             + last_name: `Smith` (string)
             + email: `john@teamleader.eu` (string)
             + telephones (array[Telephone])
-            + language: `nl-BE` (enum[string])
+            + language: `nl-BE` (enum)
                 + Members
                     + da-DK
                     + de-DE
@@ -128,7 +128,7 @@ Get details for a single user.
                     + tr-TR
             + function: `Sales` (string)
             + time_zone: `Europe/Brussels` (string)
-            + status: `active` (enum[string])
+            + status: `active` (enum)
                 + Members
                     + active
                     + deactivated

--- a/src/02-crm/companies.apib
+++ b/src/02-crm/companies.apib
@@ -13,7 +13,7 @@ Get a list of companies.
     + Attributes (object)
         + filter (object, optional)
             + email (object, optional)
-                + type: `primary` (enum[string], required)
+                + type: `primary` (enum, required)
                     + Members
                          + primary
                 + email: `info@piedpiper.eu` (string, required)
@@ -24,12 +24,12 @@ Get a list of companies.
         + page (Page, optional)
         + sort (array, optional)
             + (object)
-                + field (enum[string], required)
+                + field (enum, required)
                     + Members
                         + name
                         + added_at
                         + updated_at
-                + order (enum[string], optional)
+                + order (enum, optional)
                     + Members
                         + asc
                         + desc
@@ -52,7 +52,7 @@ Get a list of companies.
                 + national_identification_number: `63326426` (string)
                 + emails (array)
                     + (object)
-                        + type: `primary` (enum[string])
+                        + type: `primary` (enum)
                             + Members
                                 + primary
                                 + invoicing
@@ -97,7 +97,7 @@ Get details for a single company.
             + national_identification_number: `63326426` (string)
             + emails (array)
                 + (object)
-                    + type: `primary` (enum[string])
+                    + type: `primary` (enum)
                         + Members
                             + primary
                             + invoicing
@@ -106,7 +106,7 @@ Get details for a single company.
             + website: `https://piedpiper.com` (string)
             + addresses (array)
                 + (object)
-                    + type: `invoicing` (enum[string])
+                    + type: `invoicing` (enum)
                         + Members
                             + primary
                             + invoicing
@@ -144,7 +144,7 @@ Add a new company.
         + national_identification_number: `63326426` (string, optional)
         + emails (array, optional)
             + (object)
-                + type: `primary` (enum[string], required)
+                + type: `primary` (enum, required)
                     + Members
                         + primary
                         + invoicing
@@ -153,7 +153,7 @@ Add a new company.
         + website: `http://example.com` (string, optional)
         + addresses (array, optional)
             + (object)
-                + type: `invoicing` (enum[string], required)
+                + type: `invoicing` (enum, required)
                     + Members
                         + primary
                         + invoicing
@@ -190,7 +190,7 @@ Update a company.
         + national_identification_number: `63326426` (string, optional, nullable)
         + emails (array, optional)
             + (object)
-                + type: `primary` (enum[string], required)
+                + type: `primary` (enum, required)
                     + Members
                         + primary
                         + invoicing
@@ -199,7 +199,7 @@ Update a company.
         + website: `http://example.com` (string, optional)
         + addresses (array, optional)
             + (object)
-                + type: `invoicing` (enum[string], required)
+                + type: `invoicing` (enum, required)
                     + Members
                         + primary
                         + invoicing

--- a/src/02-crm/contacts.apib
+++ b/src/02-crm/contacts.apib
@@ -13,7 +13,7 @@ Get a list of contacts.
     + Attributes (object)
         + filter (object, optional)
             + email (object, optional)
-                + type: `primary` (enum[string], required)
+                + type: `primary` (enum, required)
                     + Members
                          + primary
                 + email: `info@piedpiper.eu` (string, required)
@@ -25,12 +25,12 @@ Get a list of contacts.
         + page (Page, optional)
         + sort (array, optional)
             + (object)
-                + field (enum[string], required)
+                + field (enum, required)
                     + Members
                         + added_at - Sorts on added_at
                         + name - Sorts alphabetically on last_name and first_name
                         + updated_at - Sorts on updated_at
-                + order (enum[string], optional)
+                + order (enum, optional)
                     + Members
                         + asc
                         + desc
@@ -50,14 +50,14 @@ Get a list of contacts.
                 + salutation: `Mr` (string)
                 + emails (array)
                     + (object)
-                        + type: `primary` (enum[string])
+                        + type: `primary` (enum)
                             + Members
                                 + primary
                         + email: `info@piedpiper.eu` (string)
                 + telephones (array[Telephone])
                 + website: `https://piedpiper.com` (string)
                 + primary_address (Address)
-                + gender: `male` (enum[string])
+                + gender: `male` (enum)
                     + Members
                         + male
                         + female
@@ -93,7 +93,7 @@ Get details for a single contact.
             + salutation: `Mr` (string)
             + emails (array)
                 + (object)
-                    + type: `primary` (enum[string])
+                    + type: `primary` (enum)
                         + Members
                             + primary
                     + email: `info@piedpiper.eu` (string)
@@ -101,14 +101,14 @@ Get details for a single contact.
             + website: `https://piedpiper.com` (string)
             + addresses (array)
                 + (object)
-                    + type: `invoicing` (enum[string])
+                    + type: `invoicing` (enum)
                         + Members
                             + primary
                             + invoicing
                             + delivery
                             + visiting
                     + address (Addressee) - Primary addresses can not contain an addressee
-            + gender: `male` (enum[string])
+            + gender: `male` (enum)
                 + Members
                     + male
                     + female
@@ -146,7 +146,7 @@ Add a new contact.
         + last_name: `Smith` (string, required)
         + emails (array, optional)
             + (object)
-                + type: `primary` (enum[string], required)
+                + type: `primary` (enum, required)
                     + Members
                         + primary
                 + email: `info@piedpiper.eu` (string, required)
@@ -155,7 +155,7 @@ Add a new contact.
         + website: `http://example.com` (string, optional)
         + addresses (array, optional)
             + (object)
-                + type: `invoicing` (enum[string], required)
+                + type: `invoicing` (enum, required)
                     + Members
                         + primary
                         + invoicing
@@ -163,7 +163,7 @@ Add a new contact.
                         + visiting
                 + address (Addressee, required) - Primary addresses can not contain an addressee
         + language: `en` (string, optional)
-        + gender: `male` (enum[string], optional)
+        + gender: `male` (enum, optional)
             + Members
                 + male
                 + female
@@ -196,7 +196,7 @@ Update a contact.
         + salutation: `Mr` (string, optional, nullable)
         + emails (array, optional)
             + (object)
-                + type: `primary` (enum[string], required)
+                + type: `primary` (enum, required)
                     + Members
                         + primary
                 + email: `info@piedpiper.eu` (string, required, nullable)
@@ -204,7 +204,7 @@ Update a contact.
         + website: `http://example.com` (string, optional, nullable)
         + addresses (array, optional)
             + (object)
-                + type: `invoicing` (enum[string], required)
+                + type: `invoicing` (enum, required)
                     + Members
                         + primary
                         + invoicing
@@ -212,7 +212,7 @@ Update a contact.
                         + visiting
                 + address (Addressee, required) - Primary addresses can not contain an addressee
         + language: `en` (string, optional)
-        + gender: `male` (enum[string], optional, nullable)
+        + gender: `male` (enum, optional, nullable)
             + Members
                 + male
                 + female

--- a/src/02-crm/tags.apib
+++ b/src/02-crm/tags.apib
@@ -12,10 +12,10 @@ Get a list of tags.
         + page (Page, optional)
         + sort (array, optional)
             + (object)
-                + field (enum[string], required)
+                + field (enum, required)
                     + Members
                         + tag
-                + order (enum[string], optional)
+                + order (enum, optional)
                     + Members
                         + asc
             + Default

--- a/src/03-deals/deals.apib
+++ b/src/03-deals/deals.apib
@@ -15,7 +15,7 @@ Get a list of deals.
             + ids: `3f507137-e599-41d4-8625-0e2adba0be4c`,`ae97f6d3-0bb4-43d3-b13d-f06069d07e98` (array[string], optional)
             + term: `Interesting deal` (string, optional) - Filters on the title, reference and customer's name
             + customer (object, optional)
-                + type (enum[string], required)
+                + type (enum, required)
                     + Members
                         + company
                         + contact
@@ -26,10 +26,10 @@ Get a list of deals.
         + page (Page, optional)
         + sort (array, optional)
             + (object)
-                + field (enum[string], required)
+                + field (enum, required)
                     + Members
                         + created_at
-                + order (enum[string], optional)
+                + order (enum, optional)
                     + Members
                         + desc
             + Default
@@ -46,7 +46,7 @@ Get a list of deals.
                 + id: `6e7fe84d-d4b3-4723-abae-9bc082d8f65a` (string)
                 + title: `Interesting deal` (string)
                 + reference: `2017/2` (string)
-                + status: `won` (enum[string])
+                + status: `won` (enum)
                     + Members
                         + new
                         + open
@@ -54,7 +54,7 @@ Get a list of deals.
                         + lost
                 + lead (object)
                     + customer (object)
-                        + type: `company` (enum[string])
+                        + type: `company` (enum)
                             + Members
                                 + contact
                                 + company
@@ -98,14 +98,14 @@ Get details for a single deal.
             + id: `f6871b06-6513-4750-b5e6-ff3503b5a029` (string)
             + title: `Interesting deal` (string)
             + reference: `2017/2` (string)
-            + status: `won` (enum[string])
+            + status: `won` (enum)
                 + Members
                     + open
                     + won
                     + lost
             + lead (object)
                 + customer (object)
-                    + type: `company` (enum[string])
+                    + type: `company` (enum)
                         + Members
                             + contact
                             + company
@@ -156,7 +156,7 @@ Create a new deal for a customer.
     + Attributes (object)
         + lead (object, required)
             + customer (object, required)
-                + type (enum[string], required)
+                + type (enum, required)
                     + Members
                         + contact
                         + company
@@ -189,7 +189,7 @@ Update a deal.
         + id: `65a35860-dcca-4850-9fd6-47ff08469e0c` (string, required)
         + lead (object, required)
             + customer (object, required)
-                + type (enum[string], required)
+                + type (enum, required)
                     + Members
                         + contact
                         + company
@@ -263,10 +263,10 @@ Get a list of lost reasons for deals.
         + page (Page, optional)
         + sort (array, optional)
             + (object)
-                + field (enum[string], required)
+                + field (enum, required)
                     + Members
                         + name
-                + order (enum[string], optional)
+                + order (enum, optional)
                     + Members
                         + asc
             + Default

--- a/src/03-deals/quotations.apib
+++ b/src/03-deals/quotations.apib
@@ -35,14 +35,14 @@ Get a quotation
                             + extended_description: `Some more information about this awesome product` (string) - Uses Markdown formatting
                             + unit_price (object)
                                 + Include Money
-                                + tax: `excluding` (enum[string])
+                                + tax: `excluding` (enum)
                                     + Members
                                         + excluding
                             + tax (object)
                                 + type: `taxRate` (string)
                                 + id: `e2314517-3cab-4aa9-8471-450e73449042`
                             + discount (object, nullable)
-                                + type: `percentage` (enum[string])
+                                + type: `percentage` (enum)
                                     + Members
                                         + percentage
                                 + value: 15.00 (number)
@@ -64,7 +64,7 @@ Download a quotation in a specific format.
 
     + Attributes (object)
         + id: `d885e5d5-bacb-4607-bde9-abc4a04a901b` (string, required)
-        + format: `pdf` (enum[string], required)
+        + format: `pdf` (enum, required)
             + Members
                 + pdf
 

--- a/src/04-calendar/events.apib
+++ b/src/04-calendar/events.apib
@@ -19,12 +19,12 @@ Get a list of calendar events.
             + starts_before: `2018-01-01T00:00:00+00:00` (string, optional) - End of the period for which to return events
             + term: `coffee` (string, optional) - Searches for a term in title or description
             + attendee (object, optional)
-                + type (enum[string], required)
+                + type (enum, required)
                     + Members
                         + contact
                 + id: `2659dc4d-444b-4ced-b51c-b87591f604d7` (string, required)
             + link (object, optional)
-                + type (enum[string], required)
+                + type (enum, required)
                     + Members
                         + contact
                         + company
@@ -32,10 +32,10 @@ Get a list of calendar events.
         + page (Page, optional)
         + sort (array, optional)
             + (object)
-                + field: `starts_at` (enum[string], required)
+                + field: `starts_at` (enum, required)
                     + Members
                         + starts_at
-                + order: `asc` (enum[string], optional)
+                + order: `asc` (enum, optional)
                     + Members
                         + asc
                         + desc
@@ -66,14 +66,14 @@ Get a list of calendar events.
                 + location (string)
                 + attendees (array)
                     + (object)
-                        + type: `contact` (enum[string])
+                        + type: `contact` (enum)
                             + Members
                                 + user
                                 + contact
                         + id: `8b3afad7-648d-4b4c-b38b-5726d3222282` (string)
                 + links (array)
                     + (object)
-                        + type (enum[string])
+                        + type (enum)
                             + Members
                                 + company
                                 + contact
@@ -110,14 +110,14 @@ Get details for a single calendar event.
             + location (string)
             + attendees (array)
                 + (object)
-                    + type: `contact` (enum[string])
+                    + type: `contact` (enum)
                         + Members
                             + user
                             + contact
                     + id: `8b3afad7-648d-4b4c-b38b-5726d3222282` (string)
             + links (array)
                 + (object)
-                    + type (enum[string])
+                    + type (enum)
                         + Members
                             + company
                             + contact
@@ -139,14 +139,14 @@ Create a new calendar event.
         + work_type_id: `b37e2bc7-dea0-4fda-88e9-c092fb65667d` (string, optional)
         + attendees (array, optional)
             + (object)
-                + type: `user` (enum[string], required)
+                + type: `user` (enum, required)
                     + Members
                         + user
                         + contact
                 + id: `6ddd2666-65a0-497f-9f01-54c4343ec1a6` (string, required)
         + links (array, optional)
             + (object)
-                + type: `company` (enum[string], required)
+                + type: `company` (enum, required)
                     + Members
                         + company
                         + contact
@@ -175,14 +175,14 @@ Update a calendar event.
         + work_type_id: `b37e2bc7-dea0-4fda-88e9-c092fb65667d` (string, optional)
         + attendees (array, optional)
             + (object)
-                + type: `user` (enum[string], required)
+                + type: `user` (enum, required)
                     + Members
                         + user
                         + contact
                 + id: `6ddd2666-65a0-497f-9f01-54c4343ec1a6` (string, required)
         + links (array, optional)
             + (object)
-                + type: `company` (enum[string], required)
+                + type: `company` (enum, required)
                     + Members
                         + company
                         + contact

--- a/src/05-invoicing/credit-notes.apib
+++ b/src/05-invoicing/credit-notes.apib
@@ -17,10 +17,10 @@ List credit notes
         + page (Page, optional)
         + sort (array, optional)
             + (object)
-                + field (enum[string], required)
+                + field (enum, required)
                     + Members
                         + credit_note_number
-                + order (enum[string], optional)
+                + order (enum, optional)
                     + Members
                         + asc
             + Default
@@ -39,7 +39,7 @@ List credit notes
                     + id: `36386b05-936e-4cc0-9523-bd20d797ebf5` (string)
                 + credit_note_number: `2017/5` (string, nullable)
                 + credit_note_date: `2016-02-04` (string, nullable)
-                + status: `booked` (enum[string])
+                + status: `booked` (enum)
                     + Members
                         + booked
                 + invoice (object, nullable)
@@ -85,7 +85,7 @@ Get details for a single credit note
                     + id: `36386b05-936e-4cc0-9523-bd20d797ebf5` (string)
                 + credit_note_number: `2017/5` (string, nullable)
                 + credit_note_date: `2016-02-04` (string, nullable)
-                + status: `booked` (enum[string])
+                + status: `booked` (enum)
                     + Members
                         + booked
                 + invoice (object, nullable)
@@ -127,14 +127,14 @@ Get details for a single credit note
                                 + extended_description: `Some more information about this awesome product` (string) - Uses Markdown formatting
                                 + unit_price (object)
                                     + Include Money
-                                    + tax: `excluding` (enum[string])
+                                    + tax: `excluding` (enum)
                                         + Members
                                             + excluding
                                 + tax (object)
                                     + type: `taxRate` (string)
                                     + id: `e2314517-3cab-4aa9-8471-450e73449042` (string)
                                 + discount (object, nullable)
-                                    + type: `percentage` (enum[string])
+                                    + type: `percentage` (enum)
                                         + Members
                                             + percentage
                                     + value: `15.00` (number)
@@ -158,7 +158,7 @@ Download a credit note in a specific format.
 
     + Attributes (object)
         + id: `d885e5d5-bacb-4607-bde9-abc4a04a901b` (string, required)
-        + format: `pdf` (enum[string], required)
+        + format: `pdf` (enum, required)
             + Members
                 + pdf
 

--- a/src/05-invoicing/invoices.apib
+++ b/src/05-invoicing/invoices.apib
@@ -14,7 +14,7 @@ Get a list of invoices.
         + filter (object, optional)
             + ids: `cb8da52a-ce89-4bf6-8f7e-8ee6cb85e3b5`,`f8a57a6f-dd1e-41a3-b8d3-428663f1d09e` (array[string], optional)
             + department_id: `080aac72-ff1a-4627-bfe3-146b6eee979c` (string, optional) - The ID of the department you wish to filter on.
-            + status (array[enum[string]], optional) - The statuses you want to filter by.
+            + status (array[enum], optional) - The statuses you want to filter by.
                 + Members
                     + draft
                     + outstanding
@@ -25,10 +25,10 @@ Get a list of invoices.
         + page (Page, optional)
         + sort (array, optional)
             + (object)
-                + field (enum[string], required)
+                + field (enum, required)
                     + Members
                         + invoice_number
-                + order (enum[string], optional)
+                + order (enum, optional)
                     + Members
                         + asc
             + Default
@@ -47,7 +47,7 @@ Get a list of invoices.
                     + id: `5e90eb0a-b502-4344-aa0f-3b8525af6186` (string)
                 + invoice_number: `2017 / 5` (string, nullable)
                 + invoice_date: `2016-02-04` (string, nullable)
-                + status: `matched` (enum[string])
+                + status: `matched` (enum)
                     + Members
                         + draft
                         + outstanding
@@ -101,7 +101,7 @@ Get details for a single invoice.
                 + id: `8f802cba-443b-4c69-800f-5852e967000b` (string)
             + invoice_number: `2017 / 5` (string, nullable)
             + invoice_date: `2016-02-04` (string, nullable)
-            + status: `outstanding` (enum[string])
+            + status: `outstanding` (enum)
                 + Members
                     + draft
                     + outstanding
@@ -126,7 +126,7 @@ Get details for a single invoice.
                 + national_identification_number: `123` (string, nullable)
             + discounts (array)
                 + (object)
-                    + type: `percentage` (enum[string])
+                    + type: `percentage` (enum)
                         + Members
                             + percentage
                     + value: 15.00 (number)
@@ -148,14 +148,14 @@ Get details for a single invoice.
                             + extended_description: `Some more information about this awesome product` (string, nullable) - Uses Markdown formatting
                             + unit_price (object)
                                 + Include Money
-                                + tax: `excluding` (enum[string])
+                                + tax: `excluding` (enum)
                                     + Members
                                         + excluding
                             + tax (object)
                                 + type: `taxRate` (string)
                                 + id: `e2314517-3cab-4aa9-8471-450e73449042` (string)
                             + discount (object, nullable)
-                                + type: `percentage` (enum[string])
+                                + type: `percentage` (enum)
                                     + Members
                                         + percentage
                                 + value: 15.00 (number)
@@ -208,7 +208,7 @@ Download an invoice in a specific format.
 
     + Attributes (object)
         + id: `d885e5d5-bacb-4607-bde9-abc4a04a901b` (string, required)
-        + format: `pdf` (enum[string], required)
+        + format: `pdf` (enum, required)
             + Members
                 + pdf
 
@@ -228,7 +228,7 @@ Draft a new invoice.
     + Attributes (object)
         + invoicee (object, required)
             + customer (object, required)
-                + type (enum[string])
+                + type (enum)
                     + Members
                         + contact
                         + company
@@ -251,14 +251,14 @@ Draft a new invoice.
                         + extended_description: `Some more information about this awesome product` (string, optional, nullable) - Uses Markdown formatting
                         + unit_price (object)
                             + Include Money
-                            + tax: `excluding` (enum[string], required)
+                            + tax: `excluding` (enum, required)
                                 + Members
                                     + excluding
                         + tax_rate_id: `c0c03f1e-77e3-402c-a713-30ea1c585823` (string, required)
                         + withholding_tax_rate_id: `c0c03f1e-77e3-402c-a713-30ea1c585824` (string, optional)
                         + discount (object, optional)
                             + value: 10 (number, required)
-                            + type (enum[string], required)
+                            + type (enum, required)
                                 + Members
                                     + percentage - Values between 0 and 100
                         + product_category_id: `e2314517-3cab-4aa9-8471-450e73449041` (string, optional)
@@ -266,7 +266,7 @@ Draft a new invoice.
         + discounts (array, optional)
             (object)
                 + value: 10 (number, required)
-                + type (enum[string], required)
+                + type (enum, required)
                     + Members
                         + percentage - Values between 0 and 100
                 + description: `winter promotion` (string, required)
@@ -290,7 +290,7 @@ Update an invoice.
         + id: `b7023c11-455e-4fa5-bb96-87f37dbc7d07` (string, required)
         + invoicee (object, optional)
             + customer (object, required)
-                + type (enum[string])
+                + type (enum)
                     + Members
                         + contact
                         + company
@@ -312,14 +312,14 @@ Update an invoice.
                         + extended_description: `Some more information about this awesome product` (string, optional, nullable) - Uses Markdown formatting
                         + unit_price (object)
                             + Include Money
-                            + tax: `excluding` (enum[string])
+                            + tax: `excluding` (enum)
                                 + Members
                                     + excluding
                         + tax_rate_id: `c0c03f1e-77e3-402c-a713-30ea1c585823` (string, required)
                         + withholding_tax_rate_id: `c0c03f1e-77e3-402c-a713-30ea1c585824` (string, optional)
                         + discount (object, optional)
                             + value: 10 (number, required)
-                            + type (enum[string], required)
+                            + type (enum, required)
                                 + Members
                                     + percentage - Values between 0 and 100
                         + product_category_id: `e2314517-3cab-4aa9-8471-450e73449041` (string, optional)
@@ -328,7 +328,7 @@ Update an invoice.
         + discounts (array, optional)
             (object)
                 + value: 10 (number, required)
-                + type (enum[string], required)
+                + type (enum, required)
                     + Members
                         + percentage - Values between 0 and 100
                 + description: `winter promotion` (string, required)

--- a/src/07-projects/milestones.apib
+++ b/src/07-projects/milestones.apib
@@ -14,7 +14,7 @@ Get a list of project milestones.
         + filter (object, optional)
             + ids: `bbbfe0da-e692-4ee3-9d3d-0716808d6523`,`722e1eb9-53d5-4b8c-9d17-154dcc65c610` (array[string], optional)
             + project_id: `082e6289-30c5-45ad-bcd0-190b02d21e81` (string, optional)
-            + status (enum[string], optional)
+            + status (enum, optional)
                 + Members
                     + open
                     + closed
@@ -23,10 +23,10 @@ Get a list of project milestones.
         + page (Page, optional)
         + sort (array, optional)
             + (object)
-                + field (enum[string], required)
+                + field (enum, required)
                     + Members
                         + due_on
-                + order (enum[string], optional)
+                + order (enum, optional)
                     + Members
                         + asc
             + Default
@@ -48,11 +48,11 @@ Get a list of project milestones.
                 + responsible_user (object)
                     + type: `user` (string)
                     + id: `e1240972-6cfc-4549-b49c-edda7568cc48` (string)
-                + status: `done` (enum[string])
+                + status: `done` (enum)
                     + Members
                         + open
                         + closed
-                + `invoicing_method`: `time_and_materials` (enum[string])
+                + `invoicing_method`: `time_and_materials` (enum)
                     + Members
                         + time_and_materials
                         + fixed_price
@@ -80,11 +80,11 @@ Get details for a single milestone.
             + responsible_user (object)
                 + type: `user` (string)
                 + id: `e1240972-6cfc-4549-b49c-edda7568cc48` (string)
-            + status: `done` (enum[string])
+            + status: `done` (enum)
                 + Members
                     + open
                     + closed
-            + `invoicing_method`: `time_and_materials` (enum[string])
+            + `invoicing_method`: `time_and_materials` (enum)
                 + Members
                     + time_and_materials
                     + fixed_price

--- a/src/07-projects/project-items.apib
+++ b/src/07-projects/project-items.apib
@@ -13,7 +13,7 @@ Get a list of project items.
     + Attributes (object)
         + filter (object, required)
             + project_id: `082e6289-30c5-45ad-bcd0-190b02d21e81` (string, required)
-            + type: `tracked_time` (enum[string], optional)
+            + type: `tracked_time` (enum, optional)
                 + Members
                     + tracked_time
                     + external_cost_item
@@ -26,7 +26,7 @@ Get a list of project items.
         + page (Page, optional)
         + sort (array, optional)
             + (object)
-                + field (enum[string], required)
+                + field (enum, required)
                     + Members
                         + occurred_at
                         + milestone_name
@@ -35,7 +35,7 @@ Get a list of project items.
                         + quantity
                         + cost
                         + price
-                + order (enum[string], optional)
+                + order (enum, optional)
                     + Members
                         + asc
                         + desc
@@ -56,7 +56,7 @@ Get a list of project items.
                 + milestone (object, nullable)
                     + type: `milestone` (string)
                     + id: `944534fb-15f1-4eea-aab1-82a427aa2d0d` (string)
-                + type: `tracked_time` (enum[string])
+                + type: `tracked_time` (enum)
                     + Members
                         + tracked_time
                         + external_cost_item
@@ -108,7 +108,7 @@ Get details for a single project item.
             + milestone (object, nullable)
                 + type: `milestone` (string)
                 + id: `944534fb-15f1-4eea-aab1-82a427aa2d0d` (string)
-            + type: `tracked_time` (enum[string])
+            + type: `tracked_time` (enum)
                 + Members
                     + tracked_time
                     + external_cost_item
@@ -135,7 +135,7 @@ Get details for a single project item.
                 + type: `activityType` (string)
                 + id: `ec907500-37d0-0245-8b16-2dbedd0a8ee0` (string)
             + subject (object, nullable)
-                + type: `task` (enum[string])
+                + type: `task` (enum)
                     + Members
                         + company
                         + contact

--- a/src/07-projects/projects.apib
+++ b/src/07-projects/projects.apib
@@ -13,12 +13,12 @@ Get a list of projects.
     + Attributes (object)
         + filter (object, optional)
             + customer (object, optional)
-                + type (enum[string], required)
+                + type (enum, required)
                     + Members
                         + company
                         + contact
                 + id: `ebafa4c5-fa8a-4409-92e5-1b192243372f` (string, required)
-            + status (enum[string], optional)
+            + status (enum, optional)
                 + Members
                     + active
                     + on_hold
@@ -29,10 +29,10 @@ Get a list of projects.
         + page (Page, optional)
         + sort (array, optional)
             + (object)
-                + field (enum[string], required)
+                + field (enum, required)
                     + Members
                         + due_on
-                + order (enum[string], optional)
+                + order (enum, optional)
                     + Members
                         + asc
             + Default
@@ -49,7 +49,7 @@ Get a list of projects.
                 + reference: `PRO-2` (string)
                 + title: `New company website` (string)
                 + description (string)
-                + status: `active` (enum[string])
+                + status: `active` (enum)
                     + Members
                         + active
                         + on_hold
@@ -82,14 +82,14 @@ Get details for a single project.
             + reference: `PRO-1` (string)
             + title: `New company website` (string)
             + description (string)
-            + status: `active` (enum[string])
+            + status: `active` (enum)
                 + Members
                     + active
                     + on_hold
                     + done
                     + cancelled
             + customer (object)
-                + type: `contact` (enum[string])
+                + type: `contact` (enum)
                     + Members
                         + contact
                         + company
@@ -106,11 +106,11 @@ Get details for a single project.
             + participants (array)
                 + (object)
                     + participant (object)
-                        + type: `user` (enum[string])
+                        + type: `user` (enum)
                             + Members
                                 + user
                         + id: `b0ef899b-143c-4708-90ce-aecb3350e116` (string)
-                    + role (enum[string])
+                    + role (enum)
                         + Members
                             + decision_maker
                             + member
@@ -136,13 +136,13 @@ Create a new project.
                 + participant (object, required)
                     + type: `user` (string, required)
                     + id: `e1240972-6cfc-4549-b49c-edda7568cc48` (string, required)
-                + role (enum[string], optional)
+                + role (enum, optional)
                     + Members
                         + decision_maker
                         + member
                     + Default: `member`
         + customer (object, optional)
-            + type (enum[string], required)
+            + type (enum, required)
                 + Members
                     + contact
                     + company
@@ -166,7 +166,7 @@ Update a project.
         + id: `dcc2e8ed-51be-4cb6-9c01-034aedac86fd` (string, required)
         + title: `New company website` (string, required)
         + description (string, required)
-        + status: `active` (enum[string], required)
+        + status: `active` (enum, required)
             + Members
                 + active
                 + on_hold
@@ -200,7 +200,7 @@ Add a participant to a project.
         + participant (object, required)
             + type: `user` (string)
             + id: `a1388f3d-6116-4792-ac1c-04657697539e` (string)
-        + role (enum[string], optional)
+        + role (enum, optional)
             + Members
                 + decision_maker
                 + member
@@ -220,7 +220,7 @@ Update a participant's role for a project.
         + participant (object, optional)
             + type: `user` (string)
             + id: `5ccbc008-f65e-4192-836c-4d7e21f54052` (string)
-        + role (enum[string], required)
+        + role (enum, required)
             + Members
                 + decision_maker
                 + member

--- a/src/08-tasks/tasks.apib
+++ b/src/08-tasks/tasks.apib
@@ -16,10 +16,10 @@ Get a list of tasks.
         + page (Page, optional)
         + sort (array, optional)
             + (object)
-                + field (enum[string], required)
+                + field (enum, required)
                     + Members
                         + due_at
-                + order (enum[string], optional)
+                + order (enum, optional)
                     + Members
                         + asc
                         + desc
@@ -39,7 +39,7 @@ Get a list of tasks.
                 + completed_at: `2016-02-04T16:44:33+00:00` (string)
                 + due_at: `2016-02-04T16:44:33+00:00` (string)
                 + estimated_duration (object)
-                    + unit (enum[string])
+                    + unit (enum)
                         + Members
                             + min - Minutes
                     + value: `60` (number)
@@ -47,13 +47,13 @@ Get a list of tasks.
                     + type: `workType` (string)
                     + id: `32665afd-1818-0ed3-9e18-a603a3a21b95` (string)
                 + assignee (object)
-                    + type: `user` (enum[string])
+                    + type: `user` (enum)
                         + Members
                             + user
                             + team
                     + id: `f29abf48-337d-44b4-aad4-585f5277a456` (string)
                 + customer (object, nullable)
-                    + type: `contact` (enum[string])
+                    + type: `contact` (enum)
                         + Members
                             + contact
                             + company
@@ -84,7 +84,7 @@ Get information about a task.
             + completed_at: `2016-02-04T16:44:33+00:00` (string)
             + due_at: `2016-02-04T16:44:33+00:00` (string)
             + estimated_duration (object)
-                + unit (enum[string])
+                + unit (enum)
                     + Members
                         + min - Minutes
                 + value: `60` (number)
@@ -92,13 +92,13 @@ Get information about a task.
                 + type: `workType` (string)
                 + id: `32665afd-1818-0ed3-9e18-a603a3a21b95` (string)
             + assignee (object)
-                + type: `user` (enum[string])
+                + type: `user` (enum)
                     + Members
                         + user
                         + team
                 + id: `f29abf48-337d-44b4-aad4-585f5277a456` (string)
             + customer (object, nullable)
-                + type: `contact` (enum[string])
+                + type: `contact` (enum)
                     + Members
                         + contact
                         + company
@@ -123,18 +123,18 @@ Create a new task.
         + milestone_id: `32665afd-1818-0ed3-9e18-a603a3a21b95` (string, optional)
         + deal_id: `32665afd-1818-0ed3-9e18-a603a3a21b95` (string, optional)
         + estimated_duration (object, optional)
-            + unit (enum[string], required)
+            + unit (enum, required)
                 + Members
                     + min - Minutes
             + value: `60` (number, required)
         + assignee (object, optional)
-            + type: `user` (enum[string])
+            + type: `user` (enum)
                 + Members
                     + user
                     + team
             + id: `f29abf48-337d-44b4-aad4-585f5277a456` (string)
         + customer (object, optional)
-            + type: `contact` (enum[string])
+            + type: `contact` (enum)
                 + Members
                     + contact
                     + company
@@ -161,18 +161,18 @@ Update a task.
         + milestone_id: `32665afd-1818-0ed3-9e18-a603a3a21b95` (string, optional, nullable)
         + deal_id: `32665afd-1818-0ed3-9e18-a603a3a21b95` (string, optional, nullable)
         + estimated_duration (object, optional)
-            + unit (enum[string], required)
+            + unit (enum, required)
                 + Members
                     + min - Minutes
             + value: `60` (number, required)
         + assignee (object, optional)
-            + type: `user` (enum[string])
+            + type: `user` (enum)
                 + Members
                     + user
                     + team
             + id: `f29abf48-337d-44b4-aad4-585f5277a456` (string)
         + customer (object, optional)
-            + type: `contact` (enum[string])
+            + type: `contact` (enum)
                 + Members
                     + contact
                     + company

--- a/src/08-time-tracking/time-tracking.apib
+++ b/src/08-time-tracking/time-tracking.apib
@@ -18,10 +18,10 @@ Get a list of tracked time.
         + page (Page, optional)
         + sort (array, optional)
             + (object)
-                + field (enum[string], required)
+                + field (enum, required)
                     + Members
                         + started_on
-                + order (enum[string], optional)
+                + order (enum, optional)
                     + Members
                         + desc
             + Default
@@ -47,7 +47,7 @@ Get a list of tracked time.
                 + duration: 3600 (number) - In seconds
                 + description: `Timer description` (string)
                 + subject (object)
-                    + type: `milestone` (enum[string])
+                    + type: `milestone` (enum)
                         + Members
                             + company
                             + contact
@@ -84,7 +84,7 @@ Get information about tracked time.
             + duration: 3600 (number) - In seconds
             + description: `Timer description` (string)
             + subject (object)
-                + type: `milestone` (enum[string])
+                + type: `milestone` (enum)
                     + Members
                         + company
                         + contact
@@ -114,7 +114,7 @@ Add tracked time.
                 + ended_at: `2017-04-26T16:02:00+00:00` (string, required)
         + description (string, optional)
         + subject (object, optional)
-            + type: `milestone` (enum[string], required)
+            + type: `milestone` (enum, required)
                 + Members
                     + company
                     + contact
@@ -147,7 +147,7 @@ Update tracked time.
                 + duration: 3600 (number, required) - In seconds
         + description (string, optional, nullable)
         + subject (object, optional, nullable)
-            + type: `milestone` (enum[string], required)
+            + type: `milestone` (enum, required)
                 + Members
                     + company
                     + contact

--- a/src/08-time-tracking/timers.apib
+++ b/src/08-time-tracking/timers.apib
@@ -20,7 +20,7 @@ Get the current running timer.
             + started_at: `2017-04-26T10:01:49+00:00` (string)
             + description: `Timer description` (string)
             + subject (object)
-                + type: `milestone` (enum[string])
+                + type: `milestone` (enum)
                     + Members
                         + company
                         + contact
@@ -42,7 +42,7 @@ Start a new timer.
         + started_at: `2017-04-26T10:01:49+00:00` (string, optional) - If not provided, current time will be used
         + description (string, optional)
         + subject (object, optional)
-            + type: `milestone` (enum[string], required)
+            + type: `milestone` (enum, required)
                 + Members
                     + company
                     + contact
@@ -87,7 +87,7 @@ Update the current timer. Only possible if there is a timer running.
         + started_at: `2017-04-26T10:01:49+00:00` (string, optional)
         + description: `Timer Description` (string, optional, nullable)
         + subject (object, optional, nullable)
-            + type: `milestone` (enum[string], required)
+            + type: `milestone` (enum, required)
                 + Members
                     + company
                     + contact

--- a/src/09-workorders/work-orders.apib
+++ b/src/09-workorders/work-orders.apib
@@ -8,7 +8,7 @@ Add a draft work order.
 
     + Attributes (object)
        + customer (object, required)
-           + type (enum[string], required)
+           + type (enum, required)
                + Members
                    + contact
                    + company

--- a/src/99-other/migrating.apib
+++ b/src/99-other/migrating.apib
@@ -10,7 +10,7 @@ Translates an ID from the deprecated API into a new UUID.
 + Request (application/json)
 
     + Attributes (object)
-        + type: `contact` (enum[string])
+        + type: `contact` (enum)
             + Members
                 + account
                 + user
@@ -35,7 +35,7 @@ Translates an ID from the deprecated API into a new UUID.
 
     + Attributes
         + data (object)
-            + type: `contact` (enum[string])
+            + type: `contact` (enum)
                 + Members
                     + account
                     + user
@@ -79,7 +79,7 @@ Translates "meeting", "call" and "task" into their respective activity type UUID
 + Request (application/json)
 
     + Attributes (object)
-        + type: `meeting` (enum[string])
+        + type: `meeting` (enum)
             + Members
                 + meeting
                 + call

--- a/src/datastructures.apib
+++ b/src/datastructures.apib
@@ -1,7 +1,7 @@
 # Data Structures
 
 ## Telephone (object)
-+ type: `phone` (enum[string], required)
++ type: `phone` (enum, required)
     + Members
         + phone
         + mobile
@@ -9,7 +9,7 @@
 + number: `092980615` (string, required)
 
 ## CompanyTelephone (object)
-+ type: `phone` (enum[string], required)
++ type: `phone` (enum, required)
     + Members
         + phone
         + fax
@@ -27,7 +27,7 @@
 
 ## Money (object)
 + amount: `123.30` (number, required)
-+ currency: `EUR` (enum[string], required)
++ currency: `EUR` (enum, required)
     + Members
         + BAM
         + CAD
@@ -64,7 +64,7 @@
 + number: `2` (number)
 
 ## PaymentTerm  (object)
-+ type (enum[string])
++ type (enum)
     + Members
         + cash - Direct payment, often cash
         + end_of_month - End of the month of Xth day after the invoice date
@@ -81,7 +81,7 @@
     + value: `foo`,`bar` (array[string]) - For multiple selection fields
     + value: true (boolean) - For Yes/No fields
     + value (object) - For related Teamleader objects
-        + type: `company` (enum[string])
+        + type: `company` (enum)
             + Members
                 + company
                 + contact
@@ -97,7 +97,7 @@
     + value: `foo`,`bar` (array[string]) - For multiple selection fields
     + value: true (boolean) - For Yes/No fields
     + value (object) - For related Teamleader objects
-        + type: `company` (enum[string])
+        + type: `company` (enum)
             + Members
                 + company
                 + contact
@@ -107,7 +107,7 @@
 
 ## WebHook (object)
 + url: `https://example.com` (string, required) - Your webhook URL
-+ types (array[enum[string]], required) - Array of event types that fire the webhook
++ types (array[enum], required) - Array of event types that fire the webhook
     + Members
         + account.deactivated
         + account.deleted


### PR DESCRIPTION
There's an issue when rendering `enum[string]` in request attributes (notice the extra `string`):

![Screenshot 2019-07-09 at 17 36 55](https://user-images.githubusercontent.com/550401/60906928-37efa580-a270-11e9-8a58-f12ec9ba410e.png)

Since:

1. `string` is the default type for enums
1. our enums are, as of now, always of type `string`

Let's remove the type everywhere, which fixes the issue:

![Screenshot 2019-07-09 at 17 40 11](https://user-images.githubusercontent.com/550401/60907106-9e74c380-a270-11e9-9b63-796743209a1d.png)




