### PR TITLE
Budget on `projects.info` [PRO-2147]

### DIFF
--- a/apiary.apib
+++ b/apiary.apib
@@ -3156,6 +3156,8 @@ Get a list of project milestones.
                         + time_and_materials
                         + fixed_price
                         + non_invoiceable
+                + `budget` (object) - This is only available for users that have access to budgets on projects.
+                    + `spent` (Money)
 
 ### milestones.info [GET /milestones.info]
 

--- a/apiary.apib
+++ b/apiary.apib
@@ -3190,6 +3190,8 @@ Get details for a single milestone.
                     + time_and_materials
                     + fixed_price
                     + non_invoiceable
+            + `budget` (object) - This is only available for users that have access to budgets on projects.
+                + `spent` (Money)
 
 ### milestones.create [POST /milestones.create]
 

--- a/apiary.apib
+++ b/apiary.apib
@@ -3079,7 +3079,15 @@ Get details for a single project.
                         + Members
                             + decision_maker
                             + member
-
+            + budget (object) - Only available for users with access to project budgets
+                + provided (Money)
+                + spent (object)
+                    + total (Money)
+                    + time (Money)
+                    + materials (Money)
+                + remaining (Money) - The provided budget minus the actual spent budget
+                + allocated (Money) - The amount of money still expected to spend
+                + forecasted (Money) - The budget needed at completion of the project
 
 ### projects.create [POST /projects.create]
 

--- a/src/07-projects/milestones.apib
+++ b/src/07-projects/milestones.apib
@@ -91,6 +91,8 @@ Get details for a single milestone.
                     + time_and_materials
                     + fixed_price
                     + non_invoiceable
+            + `budget` (object) - This is only available for users that have access to budgets on projects.
+                + `spent` (Money)
 
 ### milestones.create [POST /milestones.create]
 

--- a/src/07-projects/milestones.apib
+++ b/src/07-projects/milestones.apib
@@ -57,6 +57,8 @@ Get a list of project milestones.
                         + time_and_materials
                         + fixed_price
                         + non_invoiceable
+                + `budget` (object) - This is only available for users that have access to budgets on projects.
+                    + `spent` (Money)
 
 ### milestones.info [GET /milestones.info]
 

--- a/src/07-projects/projects.apib
+++ b/src/07-projects/projects.apib
@@ -114,7 +114,15 @@ Get details for a single project.
                         + Members
                             + decision_maker
                             + member
-
+            + budget (object) - Only available for users with access to project budgets
+                + provided (Money)
+                + spent (object)
+                    + total (Money)
+                    + time (Money)
+                    + materials (Money)
+                + remaining (Money) - The provided budget minus the actual spent budget
+                + allocated (Money) - The amount of money still expected to spend
+                + forecasted (Money) - The budget needed at completion of the project
 
 ### projects.create [POST /projects.create]
 


### PR DESCRIPTION
We want to expose our Better Budgets™ values to the api. This will only be available for users with access to project budgets. The spent budget is divided amongst time and materials. That division does not make sense for the other values.