### PR TITLE
Added budget to projects.info [PRO-2147]

### DIFF
--- a/apiary.apib
+++ b/apiary.apib
@@ -371,6 +371,8 @@ We list all backwards-compatible additions here. These are currently available i
 
 #### Latest
 
+- We added `budget` to `projects.info` with the provided budget, spent budget, remaining budget, allocated budget and forecasted budget.
+
 - We added a filter by `subject` to `timeTracking.list`.
 
 - A `task_id` filter has been added to `/events.list`.
@@ -3079,6 +3081,15 @@ Get details for a single project.
                         + Members
                             + decision_maker
                             + member
+            + budget (object) - Only available for users with access to project budgets
+                + provided (Money)
+                + spent (object)
+                    + total (Money)
+                    + time (Money)
+                    + materials (Money)
+                + remaining (Money) - The provided budget minus the actual spent budget
+                + allocated (Money) - The amount of money still expected to spend
+                + forecasted (Money) - The budget needed at completion of the project
 
 
 ### projects.create [POST /projects.create]

--- a/src/07-projects/projects.apib
+++ b/src/07-projects/projects.apib
@@ -114,6 +114,15 @@ Get details for a single project.
                         + Members
                             + decision_maker
                             + member
+            + budget (object) - Only available for users with access to project budgets
+                + provided (Money)
+                + spent (object)
+                    + total (Money)
+                    + time (Money)
+                    + materials (Money)
+                + remaining (Money) - The provided budget minus the actual spent budget
+                + allocated (Money) - The amount of money still expected to spend
+                + forecasted (Money) - The budget needed at completion of the project
 
 
 ### projects.create [POST /projects.create]

--- a/src/changes-backwards-compatible.apib
+++ b/src/changes-backwards-compatible.apib
@@ -6,6 +6,8 @@ We list all backwards-compatible additions here. These are currently available i
 
 #### Latest
 
+- We added `budget` to `projects.info` with the provided budget, spent budget, remaining budget, allocated budget and forecasted budget.
+
 - We added a filter by `subject` to `timeTracking.list`.
 
 - A `task_id` filter has been added to `/events.list`.


### PR DESCRIPTION
We want to expose our Better Budgets™ values to the api. This will only be available for users with access to project budgets. The spent budget is divided amongst time and materials. That division does not make sense for the other values.