### PR TITLE
Added project to tasks.info and tasks.list

### DIFF
--- a/apiary.apib
+++ b/apiary.apib
@@ -371,6 +371,8 @@ We list all backwards-compatible additions here. These are currently available i
 
 #### Latest
 
+- We added `project` to `tasks.info` and `tasks.list`.
+
 - We added a filter by `subject` to `timeTracking.list`.
 
 - A `task_id` filter has been added to `/events.list`.
@@ -3388,6 +3390,9 @@ Get a list of tasks.
                 + deal (object, nullable)
                     + type: `deal` (string)
                     + id: `32665afd-1818-0ed3-9e18-a603a3a21b95` (string)
+                + project (object, nullable)
+                    + type: `project` (string)
+                    + id: `bbbb772b-e7ad-06c5-935c-b0f6ef61d6bc` (string)
 
 ### tasks.info [GET /tasks.info]
 
@@ -3433,6 +3438,9 @@ Get information about a task.
             + deal (object, nullable)
                 + type: `deal` (string)
                 + id: `32665afd-1818-0ed3-9e18-a603a3a21b95` (string)
+            + project (object, nullable)
+                + type: `project` (string)
+                + id: `bbbb772b-e7ad-06c5-935c-b0f6ef61d6bc` (string)
 
 ### tasks.create [POST /tasks.create]
 

--- a/src/08-tasks/tasks.apib
+++ b/src/08-tasks/tasks.apib
@@ -65,6 +65,9 @@ Get a list of tasks.
                 + deal (object, nullable)
                     + type: `deal` (string)
                     + id: `32665afd-1818-0ed3-9e18-a603a3a21b95` (string)
+                + project (object, nullable)
+                    + type: `project` (string)
+                    + id: `bbbb772b-e7ad-06c5-935c-b0f6ef61d6bc` (string)
 
 ### tasks.info [GET /tasks.info]
 
@@ -110,6 +113,9 @@ Get information about a task.
             + deal (object, nullable)
                 + type: `deal` (string)
                 + id: `32665afd-1818-0ed3-9e18-a603a3a21b95` (string)
+            + project (object, nullable)
+                + type: `project` (string)
+                + id: `bbbb772b-e7ad-06c5-935c-b0f6ef61d6bc` (string)
 
 ### tasks.create [POST /tasks.create]
 

--- a/src/changes-backwards-compatible.apib
+++ b/src/changes-backwards-compatible.apib
@@ -6,6 +6,8 @@ We list all backwards-compatible additions here. These are currently available i
 
 #### Latest
 
+- We added `project` to `tasks.info` and `tasks.list`.
+
 - We added a filter by `subject` to `timeTracking.list`.
 
 - A `task_id` filter has been added to `/events.list`.


### PR DESCRIPTION
In order to facilitate sideloading, we've added `project` to `tasks.info` and `tasks.list`.