### PR TITLE
Add time_tracked to projects.info [PRO-2197]

### DIFF
--- a/apiary.apib
+++ b/apiary.apib
@@ -371,6 +371,8 @@ We list all backwards-compatible additions here. These are currently available i
 
 #### Latest
 
+- We added `tracked_time` to `projects.info`, with a breakdown of billable and non-billable hours.
+
 - We added a filter by `subject` to `timeTracking.list`.
 
 - A `task_id` filter has been added to `/events.list`.
@@ -3080,6 +3082,22 @@ Get details for a single project.
                         + Members
                             + decision_maker
                             + member
+            + tracked_time (object)
+                + total (object)
+                    + unit (enum)
+                        + Members
+                            + h - Hours
+                    + value: `10.25` (number)
+                + billable (object)
+                    + unit (enum)
+                        + Members
+                            + h - Hours
+                    + value: `7.50` (number)
+                + `non-billable` (object)
+                    + unit (enum)
+                        + Members
+                            + h - Hours
+                    + value: `2.75` (number)
 
 
 ### projects.create [POST /projects.create]

--- a/apiary.apib
+++ b/apiary.apib
@@ -3086,18 +3086,18 @@ Get details for a single project.
                 + total (object)
                     + unit (enum)
                         + Members
-                            + h - Hours
-                    + value: `10.25` (number)
+                            + s - Seconds
+                    + value: `12600` (number)
                 + billable (object)
                     + unit (enum)
                         + Members
-                            + h - Hours
-                    + value: `7.50` (number)
+                            + s - Seconds
+                    + value: `2700` (number)
                 + `non_billable` (object)
                     + unit (enum)
                         + Members
-                            + h - Hours
-                    + value: `2.75` (number)
+                            + s - Seconds
+                    + value: `9900` (number)
 
 
 ### projects.create [POST /projects.create]

--- a/apiary.apib
+++ b/apiary.apib
@@ -371,7 +371,7 @@ We list all backwards-compatible additions here. These are currently available i
 
 #### Latest
 
-- We added `tracked_time` to `projects.info`, with a breakdown of billable and non-billable hours.
+- We added `tracked_time` to `projects.info`, with a breakdown of billable and non-billable.
 
 - We added `project` to `tasks.info` and `tasks.list`.
 

--- a/apiary.apib
+++ b/apiary.apib
@@ -3093,7 +3093,7 @@ Get details for a single project.
                         + Members
                             + h - Hours
                     + value: `7.50` (number)
-                + `non-billable` (object)
+                + `non_billable` (object)
                     + unit (enum)
                         + Members
                             + h - Hours

--- a/src/07-projects/projects.apib
+++ b/src/07-projects/projects.apib
@@ -118,18 +118,18 @@ Get details for a single project.
                 + total (object)
                     + unit (enum)
                         + Members
-                            + h - Hours
-                    + value: `10.25` (number)
+                            + s - Seconds
+                    + value: `12600` (number)
                 + billable (object)
                     + unit (enum)
                         + Members
-                            + h - Hours
-                    + value: `7.50` (number)
+                            + s - Seconds
+                    + value: `2700` (number)
                 + `non_billable` (object)
                     + unit (enum)
                         + Members
-                            + h - Hours
-                    + value: `2.75` (number)
+                            + s - Seconds
+                    + value: `9900` (number)
 
 
 ### projects.create [POST /projects.create]

--- a/src/07-projects/projects.apib
+++ b/src/07-projects/projects.apib
@@ -125,7 +125,7 @@ Get details for a single project.
                         + Members
                             + h - Hours
                     + value: `7.50` (number)
-                + `non-billable` (object)
+                + `non_billable` (object)
                     + unit (enum)
                         + Members
                             + h - Hours

--- a/src/07-projects/projects.apib
+++ b/src/07-projects/projects.apib
@@ -114,6 +114,22 @@ Get details for a single project.
                         + Members
                             + decision_maker
                             + member
+            + tracked_time (object)
+                + total (object)
+                    + unit (enum)
+                        + Members
+                            + h - Hours
+                    + value: `10.25` (number)
+                + billable (object)
+                    + unit (enum)
+                        + Members
+                            + h - Hours
+                    + value: `7.50` (number)
+                + `non-billable` (object)
+                    + unit (enum)
+                        + Members
+                            + h - Hours
+                    + value: `2.75` (number)
 
 
 ### projects.create [POST /projects.create]

--- a/src/changes-backwards-compatible.apib
+++ b/src/changes-backwards-compatible.apib
@@ -6,6 +6,8 @@ We list all backwards-compatible additions here. These are currently available i
 
 #### Latest
 
+- We added `tracked_time` to `projects.info`, with a breakdown of billable and non-billable hours.
+
 - We added a filter by `subject` to `timeTracking.list`.
 
 - A `task_id` filter has been added to `/events.list`.


### PR DESCRIPTION
We added `tracked_time` to `projects.info`, with a breakdown of billable and non-billable.