### PR TITLE
archive the changes for July

### DIFF
--- a/apiary.apib
+++ b/apiary.apib
@@ -371,6 +371,10 @@ We list all backwards-compatible additions here. These are currently available i
 
 #### Latest
 
+
+
+#### July 2019
+
 - We added an `updated_since` filter to `products.list`
 
 - We added `project` to `tasks.info` and `tasks.list`.

--- a/src/changes-backwards-compatible.apib
+++ b/src/changes-backwards-compatible.apib
@@ -6,6 +6,10 @@ We list all backwards-compatible additions here. These are currently available i
 
 #### Latest
 
+
+
+#### July 2019
+
 - We added an `updated_since` filter to `products.list`
 
 - We added `project` to `tasks.info` and `tasks.list`.


### PR DESCRIPTION
Since we want to put the changes of July under a July header, lets add this.

(Note on why I don't make an August header straight away: because imo the latest section is mutable and the monthly sections are not. In that way people who come read now and then, know they don't have to look at _the past_ because they already read that... but are going to rer-read _Latest_)