### PR TITLE
[IN-2034] filter for created before to deals

### DIFF
--- a/apiary.apib
+++ b/apiary.apib
@@ -1588,6 +1588,7 @@ Get a list of deals.
             + phase_id: `1758e847-cc1f-04ce-bd17-5a852e8c01b4` (string, optional)
             + responsible_user_id: `98b2863e-7b01-4232-82f5-ede1f0b9db22` (string, optional)
             + updated_since: `2018-02-11T16:45:30+00:00` (string, optional)
+            + created_before: `2017-05-09T16:45:30+00:00` (string, optional)
         + page (Page, optional)
         + sort (array, optional)
             + (object)

--- a/src/03-deals/deals.apib
+++ b/src/03-deals/deals.apib
@@ -23,6 +23,7 @@ Get a list of deals.
             + phase_id: `1758e847-cc1f-04ce-bd17-5a852e8c01b4` (string, optional)
             + responsible_user_id: `98b2863e-7b01-4232-82f5-ede1f0b9db22` (string, optional)
             + updated_since: `2018-02-11T16:45:30+00:00` (string, optional)
+            + created_before: `2017-05-09T16:45:30+00:00` (string, optional)
         + page (Page, optional)
         + sort (array, optional)
             + (object)


### PR DESCRIPTION
For the new smart filters in the deals pipeline we will need to be able to filter on and return deals that were created before a certain date. 