### PR TITLE
🐛Fix milestone status

### DIFF
--- a/apiary.apib
+++ b/apiary.apib
@@ -3263,7 +3263,7 @@ Get a list of project milestones.
                 + responsible_user (object)
                     + type: `user` (string)
                     + id: `e1240972-6cfc-4549-b49c-edda7568cc48` (string)
-                + status: `done` (enum)
+                + status: `open` (enum)
                     + Members
                         + open
                         + closed
@@ -3295,7 +3295,7 @@ Get details for a single milestone.
             + responsible_user (object)
                 + type: `user` (string)
                 + id: `e1240972-6cfc-4549-b49c-edda7568cc48` (string)
-            + status: `done` (enum)
+            + status: `open` (enum)
                 + Members
                     + open
                     + closed

--- a/src/07-projects/milestones.apib
+++ b/src/07-projects/milestones.apib
@@ -49,7 +49,7 @@ Get a list of project milestones.
                 + responsible_user (object)
                     + type: `user` (string)
                     + id: `e1240972-6cfc-4549-b49c-edda7568cc48` (string)
-                + status: `done` (enum)
+                + status: `open` (enum)
                     + Members
                         + open
                         + closed
@@ -81,7 +81,7 @@ Get details for a single milestone.
             + responsible_user (object)
                 + type: `user` (string)
                 + id: `e1240972-6cfc-4549-b49c-edda7568cc48` (string)
-            + status: `done` (enum)
+            + status: `open` (enum)
                 + Members
                     + open
                     + closed


### PR DESCRIPTION
### Fixed

* Changed the default member value of a milestone to a valid member (there is no `done` status for a milestone, it's either `open` or `closed`)