### PR TITLE
[PRO-2919] Documentation: the tasks can now be unassigned

### DIFF
--- a/apiary.apib
+++ b/apiary.apib
@@ -374,6 +374,8 @@ We list all backwards-compatible additions here. These are currently available i
 
 #### Latest
 
+- The task assignee is now nullable.
+
 - We added `milestones.delete`.
 
 - We added a `estimated_closing_date` filter to `deals.list`.
@@ -524,10 +526,6 @@ _This will only affect the version for those API calls and won't affect any othe
 ### Changelog
 
 We list all backwards-incompatible changes here. As described above, new additions and forwards-compatible changes don’t need a new API version and can be found [here](#additions).
-
-#### 2019-12-11
-
-- The task assignee is now nullable.
 
 #### 2019-10-09
 

--- a/apiary.apib
+++ b/apiary.apib
@@ -525,6 +525,10 @@ _This will only affect the version for those API calls and won't affect any othe
 
 We list all backwards-incompatible changes here. As described above, new additions and forwards-compatible changes don’t need a new API version and can be found [here](#additions).
 
+#### 2019-12-11
+
+- The task assignee is now nullable.
+
 #### 2019-10-09
 
 - We added `billing_method` and `budget`, and `billing_method` and `price` to `milestones.create`.
@@ -3521,7 +3525,7 @@ Create a new task.
                 + Members
                     + min - Minutes
             + value: `60` (number, required)
-        + assignee (object, optional)
+        + assignee (object, optional, nullable)
             + type: `user` (enum)
                 + Members
                     + user
@@ -3560,7 +3564,7 @@ Update a task.
                 + Members
                     + min - Minutes
             + value: `60` (number, required)
-        + assignee (object, optional)
+        + assignee (object, optional, nullable)
             + type: `user` (enum)
                 + Members
                     + user

--- a/apiary.apib
+++ b/apiary.apib
@@ -3433,7 +3433,7 @@ Get a list of tasks.
                 + work_type (object, nullable)
                     + type: `workType` (string)
                     + id: `32665afd-1818-0ed3-9e18-a603a3a21b95` (string)
-                + assignee (object)
+                + assignee (object, nullable)
                     + type: `user` (enum)
                         + Members
                             + user
@@ -3481,7 +3481,7 @@ Get information about a task.
             + work_type (object, nullable)
                 + type: `workType` (string)
                 + id: `32665afd-1818-0ed3-9e18-a603a3a21b95` (string)
-            + assignee (object)
+            + assignee (object, nullable)
                 + type: `user` (enum)
                     + Members
                         + user

--- a/apiary.apib
+++ b/apiary.apib
@@ -374,7 +374,9 @@ We list all backwards-compatible additions here. These are currently available i
 
 #### Latest
 
-- The task assignee is now nullable.
+- The task assignee is now nullable: you can create / update unassigned tasks by sending null as assignee. The tasks.list and tasks.info endpoints also return null as assignee in case the task is unassigned.
+
+- On API versions older than 2019-10-09, the assignee is returned as { type: user, id: null } in case the task is unassigned.
 
 - We added `milestones.delete`.
 

--- a/src/08-tasks/tasks.apib
+++ b/src/08-tasks/tasks.apib
@@ -142,7 +142,7 @@ Create a new task.
                 + Members
                     + min - Minutes
             + value: `60` (number, required)
-        + assignee (object, optional)
+        + assignee (object, optional, nullable)
             + type: `user` (enum)
                 + Members
                     + user
@@ -181,7 +181,7 @@ Update a task.
                 + Members
                     + min - Minutes
             + value: `60` (number, required)
-        + assignee (object, optional)
+        + assignee (object, optional, nullable)
             + type: `user` (enum)
                 + Members
                     + user

--- a/src/08-tasks/tasks.apib
+++ b/src/08-tasks/tasks.apib
@@ -54,7 +54,7 @@ Get a list of tasks.
                 + work_type (object, nullable)
                     + type: `workType` (string)
                     + id: `32665afd-1818-0ed3-9e18-a603a3a21b95` (string)
-                + assignee (object)
+                + assignee (object, nullable)
                     + type: `user` (enum)
                         + Members
                             + user
@@ -102,7 +102,7 @@ Get information about a task.
             + work_type (object, nullable)
                 + type: `workType` (string)
                 + id: `32665afd-1818-0ed3-9e18-a603a3a21b95` (string)
-            + assignee (object)
+            + assignee (object, nullable)
                 + type: `user` (enum)
                     + Members
                         + user

--- a/src/changes-backwards-compatible.apib
+++ b/src/changes-backwards-compatible.apib
@@ -6,7 +6,9 @@ We list all backwards-compatible additions here. These are currently available i
 
 #### Latest
 
-- The task assignee is now nullable.
+- The task assignee is now nullable: you can create / update unassigned tasks by sending null as assignee. The tasks.list and tasks.info endpoints also return null as assignee in case the task is unassigned.
+
+- On API versions older than 2019-10-09, the assignee is returned as { type: user, id: null } in case the task is unassigned.
 
 - We added `milestones.delete`.
 

--- a/src/changes-backwards-compatible.apib
+++ b/src/changes-backwards-compatible.apib
@@ -6,6 +6,8 @@ We list all backwards-compatible additions here. These are currently available i
 
 #### Latest
 
+- The task assignee is now nullable.
+
 - We added `milestones.delete`.
 
 - We added a `estimated_closing_date` filter to `deals.list`.

--- a/src/changes-backwards-incompatible.apib
+++ b/src/changes-backwards-incompatible.apib
@@ -3,6 +3,10 @@
 
 We list all backwards-incompatible changes here. As described above, new additions and forwards-compatible changes don’t need a new API version and can be found [here](#additions).
 
+#### 2019-12-11
+
+- The task assignee is now nullable.
+
 #### 2019-10-09
 
 - We added `billing_method` and `budget`, and `billing_method` and `price` to `milestones.create`.

--- a/src/changes-backwards-incompatible.apib
+++ b/src/changes-backwards-incompatible.apib
@@ -3,10 +3,6 @@
 
 We list all backwards-incompatible changes here. As described above, new additions and forwards-compatible changes don’t need a new API version and can be found [here](#additions).
 
-#### 2019-12-11
-
-- The task assignee is now nullable.
-
 #### 2019-10-09
 
 - We added `billing_method` and `budget`, and `billing_method` and `price` to `milestones.create`.


### PR DESCRIPTION
### Ticket
Link to ticket: https://teamleader.atlassian.net/browse/PRO-2919

We are now allowing tasks to be unassigned, behind a feature flag. Before switching the feature flag on for everyone, we're preparing the API documentation for this.