### PR TITLE
Document `lead` as optional property on `deals.update`

### DIFF
--- a/apiary.apib
+++ b/apiary.apib
@@ -1785,7 +1785,7 @@ Update a deal.
 
     + Attributes (object)
         + id: `65a35860-dcca-4850-9fd6-47ff08469e0c` (string, required)
-        + lead (object, required)
+        + lead (object, optional)
             + customer (object, required)
                 + type (enum, required)
                     + Members

--- a/src/03-deals/deals.apib
+++ b/src/03-deals/deals.apib
@@ -198,7 +198,7 @@ Update a deal.
 
     + Attributes (object)
         + id: `65a35860-dcca-4850-9fd6-47ff08469e0c` (string, required)
-        + lead (object, required)
+        + lead (object, optional)
             + customer (object, required)
                 + type (enum, required)
                     + Members


### PR DESCRIPTION
A deal can be updated without having to update the lead perfectly fine. Let's correct this in the API documentation.