### PR TITLE
PRO-3171: provide  'extra_option_allowed' in customFieldDefinitions

### DIFF
--- a/apiary.apib
+++ b/apiary.apib
@@ -381,7 +381,7 @@ We list all backwards-compatible additions here. These are currently available i
 
 - We added the `weighted_value` to the response of both `deals.list` and `deals.info` requests.
 
-- We added the 'extra_option_allowed' information (for single and multiple select cusfom fields) to `customFieldDefinitions.list` and `customFieldDefinitions.info` endpoints.
+- We added the 'extra_option_allowed' information (for single and multiple select custom fields) to `customFieldDefinitions.list` and `customFieldDefinitions.info` endpoints.
 
 #### October 2019
 

--- a/apiary.apib
+++ b/apiary.apib
@@ -381,7 +381,7 @@ We list all backwards-compatible additions here. These are currently available i
 
 - We added the `weighted_value` to the response of both `deals.list` and `deals.info` requests.
 
-- We added the 'extra_option_allowed' information (for single and multiple select custom fields) to `customFieldDefinitions.list` and `customFieldDefinitions.info` endpoints.
+- We added the `extra_option_allowed` information (for single select custom fields) to `customFieldDefinitions.list` and `customFieldDefinitions.info` endpoints.
 
 #### October 2019
 

--- a/apiary.apib
+++ b/apiary.apib
@@ -381,6 +381,8 @@ We list all backwards-compatible additions here. These are currently available i
 
 - We added the `weighted_value` to the response of both `deals.list` and `deals.info` requests.
 
+- We added the 'extra_option_allowed' information (for single and multiple select cusfom fields) to `customFieldDefinitions.list` and `customFieldDefinitions.info` endpoints.
+
 #### October 2019
 
 - We added `milestones.delete`.
@@ -880,9 +882,9 @@ Get a list of all the definitions of custom fields.
                 + label (string)
                 + group (string)
                 + required: false (boolean)
-                + configuration (object)
-                    + One Of
-                        + options: foo, bar (array[string])
+                + configuration (object, optional)
+                    + options: foo, bar (array[string])
+                    + extra_option_allowed: true (boolean)
 
 ### customFieldDefinitions.info [GET /customFieldDefinitions.info]
 
@@ -931,9 +933,9 @@ Get info about a specific custom field definition.
             + label (string)
             + group (string)
             + required: false (boolean)
-            + configuration (object)
-                + One Of
-                    + options: foo, bar (array[string])
+            + configuration (object, optional)
+                + options: foo, bar (array[string])
+                + extra_option_allowed: true (boolean)
 
 ## Work Types [/workTypes]
 

--- a/src/01-general/custom-fields.apib
+++ b/src/01-general/custom-fields.apib
@@ -64,9 +64,9 @@ Get a list of all the definitions of custom fields.
                 + label (string)
                 + group (string)
                 + required: false (boolean)
-                + configuration (object)
-                    + One Of
-                        + options: foo, bar (array[string])
+                + configuration (object, optional)
+                    + options: foo, bar (array[string])
+                    + extra_option_allowed: true (boolean)
 
 ### customFieldDefinitions.info [GET /customFieldDefinitions.info]
 
@@ -115,6 +115,6 @@ Get info about a specific custom field definition.
             + label (string)
             + group (string)
             + required: false (boolean)
-            + configuration (object)
-                + One Of
-                    + options: foo, bar (array[string])
+            + configuration (object, optional)
+                + options: foo, bar (array[string])
+                + extra_option_allowed: true (boolean)

--- a/src/changes-backwards-compatible.apib
+++ b/src/changes-backwards-compatible.apib
@@ -13,6 +13,8 @@ We list all backwards-compatible additions here. These are currently available i
 
 - We added the `weighted_value` to the response of both `deals.list` and `deals.info` requests.
 
+- We added the 'extra_option_allowed' information (for single and multiple select cusfom fields) to `customFieldDefinitions.list` and `customFieldDefinitions.info` endpoints.
+
 #### October 2019
 
 - We added `milestones.delete`.

--- a/src/changes-backwards-compatible.apib
+++ b/src/changes-backwards-compatible.apib
@@ -13,7 +13,7 @@ We list all backwards-compatible additions here. These are currently available i
 
 - We added the `weighted_value` to the response of both `deals.list` and `deals.info` requests.
 
-- We added the 'extra_option_allowed' information (for single and multiple select cusfom fields) to `customFieldDefinitions.list` and `customFieldDefinitions.info` endpoints.
+- We added the 'extra_option_allowed' information (for single and multiple select custom fields) to `customFieldDefinitions.list` and `customFieldDefinitions.info` endpoints.
 
 #### October 2019
 

--- a/src/changes-backwards-compatible.apib
+++ b/src/changes-backwards-compatible.apib
@@ -13,7 +13,7 @@ We list all backwards-compatible additions here. These are currently available i
 
 - We added the `weighted_value` to the response of both `deals.list` and `deals.info` requests.
 
-- We added the 'extra_option_allowed' information (for single and multiple select custom fields) to `customFieldDefinitions.list` and `customFieldDefinitions.info` endpoints.
+- We added the `extra_option_allowed` information (for single select custom fields) to `customFieldDefinitions.list` and `customFieldDefinitions.info` endpoints.
 
 #### October 2019
 


### PR DESCRIPTION
### Added

#### Latest
 - We added the `extra_option_allowed` information (for single select custom fields) to `customFieldDefinitions.list` and `customFieldDefinitions.info` endpoints.

