### PR TITLE
Adjust documentation for deals reference property

### DIFF
--- a/apiary.apib
+++ b/apiary.apib
@@ -1645,7 +1645,7 @@ Get a list of deals.
             + (object)
                 + id: `6e7fe84d-d4b3-4723-abae-9bc082d8f65a` (string)
                 + title: `Interesting deal` (string)
-                + reference: `2017/2` (string)
+                + reference: `173` (number)
                 + status: `won` (enum)
                     + Members
                         + new
@@ -1698,7 +1698,7 @@ Get details for a single deal.
         + data (object)
             + id: `f6871b06-6513-4750-b5e6-ff3503b5a029` (string)
             + title: `Interesting deal` (string)
-            + reference: `2017/2` (string)
+            + reference: `173` (number)
             + status: `won` (enum)
                 + Members
                     + open

--- a/src/03-deals/deals.apib
+++ b/src/03-deals/deals.apib
@@ -54,7 +54,7 @@ Get a list of deals.
             + (object)
                 + id: `6e7fe84d-d4b3-4723-abae-9bc082d8f65a` (string)
                 + title: `Interesting deal` (string)
-                + reference: `2017/2` (string)
+                + reference: `173` (number)
                 + status: `won` (enum)
                     + Members
                         + new
@@ -107,7 +107,7 @@ Get details for a single deal.
         + data (object)
             + id: `f6871b06-6513-4750-b5e6-ff3503b5a029` (string)
             + title: `Interesting deal` (string)
-            + reference: `2017/2` (string)
+            + reference: `173` (number)
             + status: `won` (enum)
                 + Members
                     + open


### PR DESCRIPTION
The deal reference is a number, not a string value. Let's fix this in the documentation.