### PR TITLE
Expose the freeze time tracking preference on users.me

### DIFF
--- a/apiary.apib
+++ b/apiary.apib
@@ -732,8 +732,8 @@ Get the current authenticated user.
                 + historic_time_tracking_limit (object, nullable)
                     + unit (enum)
                         + Members
-                            + day - Days
-                    + value: 7 (number)
+                            + hour - Hours
+                    + value: 24 (number)
 
 ### users.list [GET /users.list]
 

--- a/apiary.apib
+++ b/apiary.apib
@@ -729,8 +729,11 @@ Get the current authenticated user.
             + time_zone: `Europe/Brussels` (string)
             + preferences (object)
                 + invoiceable: true (boolean)
-                + time_tracking_freezing: true (boolean)
-                + time_tracking_freezing_cutoff_days: 7 (number)
+                + historic_time_tracking_limit (object, nullable)
+                    + unit (enum)
+                        + Members
+                            + day - Days
+                    + value: 7 (number)
 
 ### users.list [GET /users.list]
 

--- a/apiary.apib
+++ b/apiary.apib
@@ -374,6 +374,8 @@ We list all backwards-compatible additions here. These are currently available i
 
 #### Latest
 
+- We exposed the "Freeze time tracking after a number of days" preference in `users.me`.
+
 - We added format `ubl/e-fff` to `invoices.download`.
 
 - We added filters `estimated_closing_date_from` and `estimated_closing_date_until` to `deals.list`.
@@ -727,6 +729,8 @@ Get the current authenticated user.
             + time_zone: `Europe/Brussels` (string)
             + preferences (object)
                 + invoiceable: true (boolean)
+                + time_tracking_freezing: true (boolean)
+                + time_tracking_freezing_cutoff_days: 7 (number)
 
 ### users.list [GET /users.list]
 

--- a/src/01-general/users.apib
+++ b/src/01-general/users.apib
@@ -40,6 +40,8 @@ Get the current authenticated user.
             + time_zone: `Europe/Brussels` (string)
             + preferences (object)
                 + invoiceable: true (boolean)
+                + time_tracking_freezing: true (boolean)
+                + time_tracking_freezing_cutoff_days: 7 (integer)
 
 ### users.list [GET /users.list]
 

--- a/src/01-general/users.apib
+++ b/src/01-general/users.apib
@@ -41,7 +41,7 @@ Get the current authenticated user.
             + preferences (object)
                 + invoiceable: true (boolean)
                 + time_tracking_freezing: true (boolean)
-                + time_tracking_freezing_cutoff_days: 7 (integer)
+                + time_tracking_freezing_cutoff_days: 7 (number)
 
 ### users.list [GET /users.list]
 

--- a/src/01-general/users.apib
+++ b/src/01-general/users.apib
@@ -43,8 +43,8 @@ Get the current authenticated user.
                 + historic_time_tracking_limit (object, nullable)
                     + unit (enum)
                         + Members
-                            + day - Days
-                    + value: 7 (number)
+                            + hour - Hours
+                    + value: 24 (number)
 
 ### users.list [GET /users.list]
 

--- a/src/01-general/users.apib
+++ b/src/01-general/users.apib
@@ -40,8 +40,11 @@ Get the current authenticated user.
             + time_zone: `Europe/Brussels` (string)
             + preferences (object)
                 + invoiceable: true (boolean)
-                + time_tracking_freezing: true (boolean)
-                + time_tracking_freezing_cutoff_days: 7 (number)
+                + historic_time_tracking_limit (object, nullable)
+                    + unit (enum)
+                        + Members
+                            + day - Days
+                    + value: 7 (number)
 
 ### users.list [GET /users.list]
 

--- a/src/changes-backwards-compatible.apib
+++ b/src/changes-backwards-compatible.apib
@@ -6,6 +6,8 @@ We list all backwards-compatible additions here. These are currently available i
 
 #### Latest
 
+- We exposed the "Freeze time tracking after a number of days" preference in `users.me`.
+
 - We added format `ubl/e-fff` to `invoices.download`.
 
 - We added filters `estimated_closing_date_from` and `estimated_closing_date_until` to `deals.list`.


### PR DESCRIPTION
When the time tracking feature is enabled, there is a setting in the Teamleader UI that prevents users from being able to add or modify time tracking entries after a certain amount of days has passed since the time tracking's end date:

![image](https://user-images.githubusercontent.com/10810561/74418552-395dfd80-4e51-11ea-8211-0919bb26e9eb.png)

![image](https://user-images.githubusercontent.com/10810561/74420642-74156500-4e54-11ea-922e-f4ac47f6a9da.png)

However, this preference is not made available to API users yet. 

This PR proposes to expose the preference on the `users.me` endpoint, so that UIs can disable editing time tracking entries when the editing cutoff time has passed.

More details on this functionality:
* the account administrators (super users) should still be able to modify entries
* when teams are used, the team leaders should still be able to modify entries for their team members, but not for themselves and not for any administrators in the team

The limitation will also be implemented on the time tracking add & update endpoints.