### PR TITLE
Lock time tracking entries

### DIFF
--- a/apiary.apib
+++ b/apiary.apib
@@ -3763,7 +3763,7 @@ Get information about tracked time.
             + invoiceable: true (boolean)
             + locked: true (boolean) - If true, the freeze time window has passed since creating it
         + meta (object)
-            + can_update: true (boolean) - If true, the current user can update the entry even if it is locked
+            + updatable: true (boolean) - If true, the current user can update the entry even if it is locked
 
 ### timeTracking.add [POST /timeTracking.add]
 

--- a/apiary.apib
+++ b/apiary.apib
@@ -3761,7 +3761,7 @@ Get information about tracked time.
                         + ticket
                 + id: `5883723a-b5aa-4c9d-a02b-ec0dd25f6ca2` (string)
             + invoiceable: true (boolean)
-            + locked: true (boolean) - If true, the time tracking entry's owner cannot update it anymore
+            + locked: true (boolean) - If true, the freeze time window has passed since creating it
         + meta (object)
             + can_update: true (boolean) - If true, the current user can update the entry even if it is locked
 

--- a/apiary.apib
+++ b/apiary.apib
@@ -374,6 +374,8 @@ We list all backwards-compatible additions here. These are currently available i
 
 #### Latest
 
+- We added the time tracking `locked` and `can_update` properties to `timeTracking.info`.
+
 - We added format `ubl/e-fff` to `invoices.download`.
 
 - We added filters `estimated_closing_date_from` and `estimated_closing_date_until` to `deals.list`.
@@ -3759,6 +3761,9 @@ Get information about tracked time.
                         + ticket
                 + id: `5883723a-b5aa-4c9d-a02b-ec0dd25f6ca2` (string)
             + invoiceable: true (boolean)
+            + locked: true (boolean) - If true, the time tracking entry's owner cannot update it anymore
+        + meta (object)
+            + can_update: true (boolean) - If true, the current user can update the entry even if it is locked
 
 ### timeTracking.add [POST /timeTracking.add]
 

--- a/apiary.apib
+++ b/apiary.apib
@@ -374,7 +374,7 @@ We list all backwards-compatible additions here. These are currently available i
 
 #### Latest
 
-- We added the time tracking `locked` and `can_update` properties to `timeTracking.info`.
+- We added the time tracking `locked` and `updatable` properties to `timeTracking.info`.
 
 - We added format `ubl/e-fff` to `invoices.download`.
 

--- a/src/08-time-tracking/time-tracking.apib
+++ b/src/08-time-tracking/time-tracking.apib
@@ -104,9 +104,9 @@ Get information about tracked time.
                         + ticket
                 + id: `5883723a-b5aa-4c9d-a02b-ec0dd25f6ca2` (string)
             + invoiceable: true (boolean)
-            + locked: true (boolean)
+            + locked: true (boolean) - If true, the time tracking entry's owner cannot update it anymore
         + meta (object)
-            + can_update: true (boolean)
+            + can_update: true (boolean) - If true, the current user can update the entry even if it is locked
 
 ### timeTracking.add [POST /timeTracking.add]
 

--- a/src/08-time-tracking/time-tracking.apib
+++ b/src/08-time-tracking/time-tracking.apib
@@ -104,6 +104,9 @@ Get information about tracked time.
                         + ticket
                 + id: `5883723a-b5aa-4c9d-a02b-ec0dd25f6ca2` (string)
             + invoiceable: true (boolean)
+            + locked: true (boolean)
+        + meta (object)
+            + can_update: true (boolean)
 
 ### timeTracking.add [POST /timeTracking.add]
 

--- a/src/08-time-tracking/time-tracking.apib
+++ b/src/08-time-tracking/time-tracking.apib
@@ -106,7 +106,7 @@ Get information about tracked time.
             + invoiceable: true (boolean)
             + locked: true (boolean) - If true, the freeze time window has passed since creating it
         + meta (object)
-            + can_update: true (boolean) - If true, the current user can update the entry even if it is locked
+            + updatable: true (boolean) - If true, the current user can update the entry even if it is locked
 
 ### timeTracking.add [POST /timeTracking.add]
 

--- a/src/08-time-tracking/time-tracking.apib
+++ b/src/08-time-tracking/time-tracking.apib
@@ -104,7 +104,7 @@ Get information about tracked time.
                         + ticket
                 + id: `5883723a-b5aa-4c9d-a02b-ec0dd25f6ca2` (string)
             + invoiceable: true (boolean)
-            + locked: true (boolean) - If true, the time tracking entry's owner cannot update it anymore
+            + locked: true (boolean) - If true, the freeze time window has passed since creating it
         + meta (object)
             + can_update: true (boolean) - If true, the current user can update the entry even if it is locked
 

--- a/src/changes-backwards-compatible.apib
+++ b/src/changes-backwards-compatible.apib
@@ -6,7 +6,7 @@ We list all backwards-compatible additions here. These are currently available i
 
 #### Latest
 
-- We added the time tracking `locked` and `can_update` properties to `timeTracking.info`.
+- We added the time tracking `locked` and `updatable` properties to `timeTracking.info`.
 
 - We added format `ubl/e-fff` to `invoices.download`.
 

--- a/src/changes-backwards-compatible.apib
+++ b/src/changes-backwards-compatible.apib
@@ -6,6 +6,8 @@ We list all backwards-compatible additions here. These are currently available i
 
 #### Latest
 
+- We added the time tracking `locked` and `can_update` properties to `timeTracking.info`.
+
 - We added format `ubl/e-fff` to `invoices.download`.
 
 - We added filters `estimated_closing_date_from` and `estimated_closing_date_until` to `deals.list`.


### PR DESCRIPTION
This PR is tied to the freezing preference PR https://github.com/teamleadercrm/api/pull/497

We are now exposing two new properties on `timeTracking.info`:

- `locked` - if true, the time tracking entry's owner cannot update it anymore (currently because the "freeze period" has passed)
- `can_update` - a meta information that the depends on the user accessing the endpoint; if true, the currently authenticated user can update the entry even if it's locked