### PR TITLE
Allow filtering on related project [PRO-3474]

### DIFF
--- a/apiary.apib
+++ b/apiary.apib
@@ -3719,6 +3719,7 @@ Get a list of tracked time.
                 + type (enum, required)
                     + Members
                         + milestone
+                        + project
                 + id: `2659dc4d-444b-4ced-b51c-b87591f604d7` (string, required)
         + page (Page, optional)
         + sort (array, optional)

--- a/src/08-time-tracking/time-tracking.apib
+++ b/src/08-time-tracking/time-tracking.apib
@@ -37,6 +37,7 @@ Get a list of tracked time.
                 + type (enum, required)
                     + Members
                         + milestone
+                        + project
                 + id: `2659dc4d-444b-4ced-b51c-b87591f604d7` (string, required)
         + page (Page, optional)
         + sort (array, optional)


### PR DESCRIPTION
We already allow filtering on related milestone, and now we add related project. So if you track time on a task, that is part of a milestone, that is part of a project, it will be returned if you filter on that related project.