### PR TITLE
[IN-2691] Pass the name of the quotation info

### DIFF
--- a/apiary.apib
+++ b/apiary.apib
@@ -1997,6 +1997,7 @@ Get a quotation
     + Attributes (object)
         + data (object)
             + id: `e7a3fe2b-2c75-480f-87b9-121816b5257b` (string)
+            + name: `Quotation 1234` (string)
             + deal (object)
                 + type: `deal` (string)
                 + id: `53474a7a-f9b2-4dd4-88a8-40ce773c7a64` (string)

--- a/apiary.apib
+++ b/apiary.apib
@@ -405,6 +405,8 @@ We list all backwards-compatible additions here. These are currently available i
 
 - We added `depends_on` to the `milestones.create` and `milestones.update` endpoints. It allows setting a dependency on another milestone of the same project.
 
+- We added `name` to the `quotations.info` response.
+
 #### October 2019
 
 - We added `milestones.delete`.

--- a/apiary.apib
+++ b/apiary.apib
@@ -405,7 +405,7 @@ We list all backwards-compatible additions here. These are currently available i
 
 - We added `depends_on` to the `milestones.create` and `milestones.update` endpoints. It allows setting a dependency on another milestone of the same project.
 
-- We added `name` to the `quotations.info` response.
+- We added `title` to the `quotations.info` response.
 
 #### October 2019
 
@@ -1999,7 +1999,7 @@ Get a quotation
     + Attributes (object)
         + data (object)
             + id: `e7a3fe2b-2c75-480f-87b9-121816b5257b` (string)
-            + name: `Quotation 1234` (string)
+            + title: `Quotation 1234` (string)
             + deal (object)
                 + type: `deal` (string)
                 + id: `53474a7a-f9b2-4dd4-88a8-40ce773c7a64` (string)

--- a/src/03-deals/quotations.apib
+++ b/src/03-deals/quotations.apib
@@ -18,6 +18,7 @@ Get a quotation
     + Attributes (object)
         + data (object)
             + id: `e7a3fe2b-2c75-480f-87b9-121816b5257b` (string)
+            + name: `Quotation 1234` (string)
             + deal (object)
                 + type: `deal` (string)
                 + id: `53474a7a-f9b2-4dd4-88a8-40ce773c7a64` (string)

--- a/src/03-deals/quotations.apib
+++ b/src/03-deals/quotations.apib
@@ -18,7 +18,7 @@ Get a quotation
     + Attributes (object)
         + data (object)
             + id: `e7a3fe2b-2c75-480f-87b9-121816b5257b` (string)
-            + name: `Quotation 1234` (string)
+            + title: `Quotation 1234` (string)
             + deal (object)
                 + type: `deal` (string)
                 + id: `53474a7a-f9b2-4dd4-88a8-40ce773c7a64` (string)

--- a/src/changes-backwards-compatible.apib
+++ b/src/changes-backwards-compatible.apib
@@ -37,7 +37,7 @@ We list all backwards-compatible additions here. These are currently available i
 
 - We added `depends_on` to the `milestones.create` and `milestones.update` endpoints. It allows setting a dependency on another milestone of the same project.
 
-- We added `name` to the `quotations.info` response.
+- We added `title` to the `quotations.info` response.
 
 #### October 2019
 

--- a/src/changes-backwards-compatible.apib
+++ b/src/changes-backwards-compatible.apib
@@ -37,6 +37,8 @@ We list all backwards-compatible additions here. These are currently available i
 
 - We added `depends_on` to the `milestones.create` and `milestones.update` endpoints. It allows setting a dependency on another milestone of the same project.
 
+- We added `name` to the `quotations.info` response.
+
 #### October 2019
 
 - We added `milestones.delete`.


### PR DESCRIPTION
We need to be consistent in displaying the names of quotations between the history and other places that we show the quotation. 
Having the backend take care of this ensures constancy between languages. 