### PR TITLE
PRO-3623 - Add purchase_order_number to projects

### DIFF
--- a/apiary.apib
+++ b/apiary.apib
@@ -374,6 +374,10 @@ We list all backwards-compatible additions here. These are currently available i
 
 #### Latest
 
+- We added the `purchase_order_number` field to `projects.info`, `projects.create`, and `projects.update`
+
+#### April 2020
+
 - We added the `description` field to `milestones.info`, `milestones.create`, and `milestones.update`
 
 - We added the `propagate_date_changes` property to `milestones.update`. This allows propagating the new due date difference to the due date of all open tasks of that milestone, and recursively to all depending milestones.
@@ -3201,6 +3205,7 @@ Get details for a single project.
                         + Members
                             + decision_maker
                             + member
+            + purchase_order_number: `000023` (string)
             + actuals (object) - Only accessible for administrators of this project
                 + `billable_amount` (Money)
                 + costs (Money)
@@ -3242,6 +3247,7 @@ Create a new project.
                         + decision_maker
                         + member
                     + Default: `member`
+        + purchase_order_number: `000023` (string, optional)
         + customer (object, optional)
             + type (enum, required)
                 + Members
@@ -3274,6 +3280,7 @@ Update a project.
                 + done
                 + cancelled
         + starts_on: `2016-02-04` (string, required)
+        + purchase_order_number: `000023` (string, optional)
 
 + Response 204 (application/json)
 

--- a/apiary.apib
+++ b/apiary.apib
@@ -3205,7 +3205,7 @@ Get details for a single project.
                         + Members
                             + decision_maker
                             + member
-            + purchase_order_number: `000023` (string)
+            + purchase_order_number: `000023` (string, nullable)
             + actuals (object) - Only accessible for administrators of this project
                 + `billable_amount` (Money)
                 + costs (Money)
@@ -3280,7 +3280,7 @@ Update a project.
                 + done
                 + cancelled
         + starts_on: `2016-02-04` (string, required)
-        + purchase_order_number: `000023` (string, optional)
+        + purchase_order_number: `000023` (string, optional, nullable)
 
 + Response 204 (application/json)
 

--- a/src/07-projects/projects.apib
+++ b/src/07-projects/projects.apib
@@ -128,6 +128,7 @@ Get details for a single project.
                         + Members
                             + decision_maker
                             + member
+            + purchase_order_number: `000023` (string)
             + actuals (object) - Only accessible for administrators of this project
                 + `billable_amount` (Money)
                 + costs (Money)
@@ -169,6 +170,7 @@ Create a new project.
                         + decision_maker
                         + member
                     + Default: `member`
+        + purchase_order_number: `000023` (string, optional)
         + customer (object, optional)
             + type (enum, required)
                 + Members
@@ -201,6 +203,7 @@ Update a project.
                 + done
                 + cancelled
         + starts_on: `2016-02-04` (string, required)
+        + purchase_order_number: `000023` (string, optional)
 
 + Response 204 (application/json)
 

--- a/src/07-projects/projects.apib
+++ b/src/07-projects/projects.apib
@@ -128,7 +128,7 @@ Get details for a single project.
                         + Members
                             + decision_maker
                             + member
-            + purchase_order_number: `000023` (string)
+            + purchase_order_number: `000023` (string, nullable)
             + actuals (object) - Only accessible for administrators of this project
                 + `billable_amount` (Money)
                 + costs (Money)
@@ -203,7 +203,7 @@ Update a project.
                 + done
                 + cancelled
         + starts_on: `2016-02-04` (string, required)
-        + purchase_order_number: `000023` (string, optional)
+        + purchase_order_number: `000023` (string, optional, nullable)
 
 + Response 204 (application/json)
 

--- a/src/changes-backwards-compatible.apib
+++ b/src/changes-backwards-compatible.apib
@@ -6,6 +6,10 @@ We list all backwards-compatible additions here. These are currently available i
 
 #### Latest
 
+- We added the `purchase_order_number` field to `projects.info`, `projects.create`, and `projects.update`
+
+#### April 2020
+
 - We added the `description` field to `milestones.info`, `milestones.create`, and `milestones.update`
 
 - We added the `propagate_date_changes` property to `milestones.update`. This allows propagating the new due date difference to the due date of all open tasks of that milestone, and recursively to all depending milestones.


### PR DESCRIPTION
Do not merge before implementation is merged!

This PR adds the "purchase_order_number" to the projects.info, projects.create and projects.update endpoints.