### PR TITLE
Custom fields on projects

### DIFF
--- a/apiary.apib
+++ b/apiary.apib
@@ -380,6 +380,8 @@ We list all backwards-compatible additions here. These are currently available i
 
 - We added the `vat_number` property to `contacts.info`.
 
+- Project custom fields are now included as `custom_fields` on `projects.info`. They can also be added and updated through the `projects.create` / `projects.update` endpoints.
+
 #### March 2020
 
 - We added actuals and budget to `projects.list`, `projects.info`, `milestones.list`, and `milestones.info`
@@ -3204,6 +3206,7 @@ Get details for a single project.
                         + Members
                             + decision_maker
                             + member
+            + custom_fields (array[CustomField])
             + actuals (object) - Only accessible for administrators of this project
                 + `billable_amount` (Money)
                 + costs (Money)
@@ -3245,6 +3248,7 @@ Create a new project.
                         + decision_maker
                         + member
                     + Default: `member`
+        + custom_fields (array[CustomFieldValue], optional)
         + customer (object, optional)
             + type (enum, required)
                 + Members
@@ -3277,6 +3281,7 @@ Update a project.
                 + done
                 + cancelled
         + starts_on: `2016-02-04` (string, required)
+        + custom_fields (array[CustomFieldValue], optional)
 
 + Response 204 (application/json)
 

--- a/src/07-projects/projects.apib
+++ b/src/07-projects/projects.apib
@@ -128,6 +128,7 @@ Get details for a single project.
                         + Members
                             + decision_maker
                             + member
+            + custom_fields (array[CustomField])
             + actuals (object) - Only accessible for administrators of this project
                 + `billable_amount` (Money)
                 + costs (Money)
@@ -169,6 +170,7 @@ Create a new project.
                         + decision_maker
                         + member
                     + Default: `member`
+        + custom_fields (array[CustomFieldValue], optional)
         + customer (object, optional)
             + type (enum, required)
                 + Members
@@ -201,6 +203,7 @@ Update a project.
                 + done
                 + cancelled
         + starts_on: `2016-02-04` (string, required)
+        + custom_fields (array[CustomFieldValue], optional)
 
 + Response 204 (application/json)
 

--- a/src/changes-backwards-compatible.apib
+++ b/src/changes-backwards-compatible.apib
@@ -12,6 +12,8 @@ We list all backwards-compatible additions here. These are currently available i
 
 - We added the `vat_number` property to `contacts.info`.
 
+- Project custom fields are now included as `custom_fields` on `projects.info`. They can also be added and updated through the `projects.create` / `projects.update` endpoints.
+
 #### March 2020
 
 - We added actuals and budget to `projects.list`, `projects.info`, `milestones.list`, and `milestones.info`


### PR DESCRIPTION
This PR adds custom field documentation for projects: on `projects.info`, `projects.create` and `projects.update`