### PR TITLE
Remove unused argument for timers.stop

### DIFF
--- a/apiary.apib
+++ b/apiary.apib
@@ -4071,11 +4071,6 @@ Start a new timer.
 
 Stop the current timer. This will add a new time tracking in the background.
 
-+ Request (application/json)
-
-    + Attributes (object)
-        + ended_at: `2017-04-26T10:01:49+00:00` (string, optional) - If not provided, current time will be used
-
 + Response 201 (application/json)
 
     + Attributes (object)

--- a/src/08-time-tracking/timers.apib
+++ b/src/08-time-tracking/timers.apib
@@ -64,11 +64,6 @@ Start a new timer.
 
 Stop the current timer. This will add a new time tracking in the background.
 
-+ Request (application/json)
-
-    + Attributes (object)
-        + ended_at: `2017-04-26T10:01:49+00:00` (string, optional) - If not provided, current time will be used
-
 + Response 201 (application/json)
 
     + Attributes (object)


### PR DESCRIPTION
Remove an argument that is never used.

The `ended_at` time is never used in the implementation.
It won't be tackled any time soon so we will remove it.

This is **no breaking change** since the request will still work (with the ignored argument) and the behaviour stays the same because it wasn't used before.