### PR TITLE
Add emails to the department list endpoint response

### DIFF
--- a/apiary.apib
+++ b/apiary.apib
@@ -372,6 +372,10 @@ We consider the following changes to be backwards-incompatible:
 We list all backwards-compatible additions here. These are currently available in all published versions.
 (There is also a [list of backwards-incompatible upgrades](#changelog) available, but those only apply if you [upgrade your API version](#upgrading-your-api-version).)
 
+### Latest
+
+- We added the `emails` property to `departments.list`.
+
 #### May 2020
 
 - We no longer require all fields in `projects.update`, only the id remains required.

--- a/apiary.apib
+++ b/apiary.apib
@@ -688,6 +688,13 @@ Get a list of departments.
                 + name: `Human Resources` (string)
                 + vat_number: `BE0899623035` (string)
                 + currency: `EUR` (string)
+                + emails (array)
+                    + (object)
+                        + type: `primary` (enum)
+                            + Members
+                                + primary
+                                + invoicing
+                        + email: `info@piedpiper.eu` (string)
 
 ### departments.info [GET /departments.info]
 

--- a/src/01-general/departments.apib
+++ b/src/01-general/departments.apib
@@ -35,6 +35,13 @@ Get a list of departments.
                 + name: `Human Resources` (string)
                 + vat_number: `BE0899623035` (string)
                 + currency: `EUR` (string)
+                + emails (array)
+                    + (object)
+                        + type: `primary` (enum)
+                            + Members
+                                + primary
+                                + invoicing
+                        + email: `info@piedpiper.eu` (string)
 
 ### departments.info [GET /departments.info]
 

--- a/src/changes-backwards-compatible.apib
+++ b/src/changes-backwards-compatible.apib
@@ -4,6 +4,10 @@
 We list all backwards-compatible additions here. These are currently available in all published versions.
 (There is also a [list of backwards-incompatible upgrades](#changelog) available, but those only apply if you [upgrade your API version](#upgrading-your-api-version).)
 
+### Latest
+
+- We added the `emails` property to `departments.list`.
+
 #### May 2020
 
 - We no longer require all fields in `projects.update`, only the id remains required.


### PR DESCRIPTION
The department emails will now be sent back with the `departments.list` response.