### PR TITLE
[PROPOSAL] Addresses | Area level two

### DIFF
--- a/apiary.apib
+++ b/apiary.apib
@@ -4258,6 +4258,9 @@ Unregister a webhook.
 + postal_code: `9000` (string, required, nullable)
 + city: `Ghent` (string, required, nullable)
 + country: `BE` (string, required)
++ area_level_two (object, nullable)
+    + type: `area_level_two` (string)
+    + id: `fd48d4a3-b9dc-4eac-8071-5889c9f21e5d` (string)
 
 ## Addressee (object)
 + addressee: `Teamleader HQ` (string, optional)

--- a/src/datastructures.apib
+++ b/src/datastructures.apib
@@ -20,6 +20,9 @@
 + postal_code: `9000` (string, required, nullable)
 + city: `Ghent` (string, required, nullable)
 + country: `BE` (string, required)
++ area_level_two (object, nullable)
+    + type: `area_level_two` (string)
+    + id: `fd48d4a3-b9dc-4eac-8071-5889c9f21e5d` (string)
 
 ## Addressee (object)
 + addressee: `Teamleader HQ` (string, optional)


### PR DESCRIPTION
Proposing to add _**Area Level Two**_ on the `Address` data structure.

Initial the plan was to roll it out for customer but because this is part of the address I opted for adding it to the `Address` object as a nullable property. 

The places affected by the change would be:
- Contacts
- Companies
- Departments 
- Work Orders

Objections?
Opinions? 