### PR TITLE
[PRO-3950] Do not require all fields on project.update endpoint

### DIFF
--- a/apiary.apib
+++ b/apiary.apib
@@ -374,6 +374,10 @@ We list all backwards-compatible additions here. These are currently available i
 
 #### Latest
 
+- We no longer require all fields in `projects.update`, only the id remains required.
+
+#### May 2020
+
 - We added the `purchase_order_number` field to `projects.info`, `projects.create`, and `projects.update`
 
 #### April 2020
@@ -3280,17 +3284,17 @@ Update a project.
 
     + Attributes (object)
         + id: `dcc2e8ed-51be-4cb6-9c01-034aedac86fd` (string, required)
-        + title: `New company website` (string, required)
-        + description (string, required)
-        + status: `active` (enum, required)
+        + title: `New company website` (string)
+        + description (string)
+        + status: `active` (enum)
             + Members
                 + active
                 + on_hold
                 + done
                 + cancelled
-        + starts_on: `2016-02-04` (string, required)
-        + purchase_order_number: `000023` (string, optional, nullable)
-        + custom_fields (array[CustomFieldValue], optional)
+        + starts_on: `2016-02-04` (string)
+        + purchase_order_number: `000023` (string, nullable)
+        + custom_fields (array[CustomFieldValue])
 
 + Response 204 (application/json)
 

--- a/src/07-projects/projects.apib
+++ b/src/07-projects/projects.apib
@@ -196,17 +196,17 @@ Update a project.
 
     + Attributes (object)
         + id: `dcc2e8ed-51be-4cb6-9c01-034aedac86fd` (string, required)
-        + title: `New company website` (string, required)
-        + description (string, required)
-        + status: `active` (enum, required)
+        + title: `New company website` (string)
+        + description (string)
+        + status: `active` (enum)
             + Members
                 + active
                 + on_hold
                 + done
                 + cancelled
-        + starts_on: `2016-02-04` (string, required)
-        + purchase_order_number: `000023` (string, optional, nullable)
-        + custom_fields (array[CustomFieldValue], optional)
+        + starts_on: `2016-02-04` (string)
+        + purchase_order_number: `000023` (string, nullable)
+        + custom_fields (array[CustomFieldValue])
 
 + Response 204 (application/json)
 

--- a/src/changes-backwards-compatible.apib
+++ b/src/changes-backwards-compatible.apib
@@ -6,6 +6,10 @@ We list all backwards-compatible additions here. These are currently available i
 
 #### Latest
 
+- We no longer require all fields in `projects.update`, only the id remains required.
+
+#### May 2020
+
 - We added the `purchase_order_number` field to `projects.info`, `projects.create`, and `projects.update`
 
 #### April 2020


### PR DESCRIPTION
We no longer require all fields to be present on the `projects.update` API endpoint.
Only the `id`is required, all other fields are optional.

Do not merge untill implementation is ready.