### PR TITLE
Set a project's end date

### DIFF
--- a/apiary.apib
+++ b/apiary.apib
@@ -3250,7 +3250,7 @@ Create a new project.
         + title: `New company website` (string, required)
         + description (string, optional)
         + starts_on: `2020-06-15` (string, required)
-        + due_on: `2020-09-15` (string, optional)
+        + due_on: `2020-09-15` (string, optional) - Defaults to the last milestone's due date when omitted
         + milestones (array, required) - At least one milestone is required
             + (object)
                 + starts_on: `2020-06-15` (string, optional)

--- a/apiary.apib
+++ b/apiary.apib
@@ -376,6 +376,8 @@ We list all backwards-compatible additions here. These are currently available i
 
 - We added the `starts_on` field on `milestones.create`, `milestones.update` and `projects.create` for milestones
 
+- We added the `due_on` field on `projects.create` and `projects.update`, in order to be able to explicitly set a project's due date.
+
 #### May 2020
 
 - We no longer require all fields in `projects.update`, only the id remains required.
@@ -3247,7 +3249,8 @@ Create a new project.
     + Attributes (object)
         + title: `New company website` (string, required)
         + description (string, optional)
-        + starts_on: `2016-02-04` (string, required)
+        + starts_on: `2020-06-15` (string, required)
+        + due_on: `2020-09-15` (string, optional)
         + milestones (array, required) - At least one milestone is required
             + (object)
                 + starts_on: `2020-06-15` (string, optional)
@@ -3297,7 +3300,8 @@ Update a project.
                 + on_hold
                 + done
                 + cancelled
-        + starts_on: `2016-02-04` (string)
+        + starts_on: `2020-02-04` (string)
+        + due_on: `2020-09-15` (string, optional)
         + purchase_order_number: `000023` (string, nullable)
         + custom_fields (array[CustomFieldValue])
 

--- a/src/07-projects/projects.apib
+++ b/src/07-projects/projects.apib
@@ -156,7 +156,7 @@ Create a new project.
         + title: `New company website` (string, required)
         + description (string, optional)
         + starts_on: `2020-06-15` (string, required)
-        + due_on: `2020-09-15` (string, optional)
+        + due_on: `2020-09-15` (string, optional) - Defaults to the last milestone's due date when omitted
         + milestones (array, required) - At least one milestone is required
             + (object)
                 + starts_on: `2020-06-15` (string, optional)

--- a/src/07-projects/projects.apib
+++ b/src/07-projects/projects.apib
@@ -155,7 +155,8 @@ Create a new project.
     + Attributes (object)
         + title: `New company website` (string, required)
         + description (string, optional)
-        + starts_on: `2016-02-04` (string, required)
+        + starts_on: `2020-06-15` (string, required)
+        + due_on: `2020-09-15` (string, optional)
         + milestones (array, required) - At least one milestone is required
             + (object)
                 + starts_on: `2020-06-15` (string, optional)
@@ -205,7 +206,8 @@ Update a project.
                 + on_hold
                 + done
                 + cancelled
-        + starts_on: `2016-02-04` (string)
+        + starts_on: `2020-02-04` (string)
+        + due_on: `2020-09-15` (string, optional)
         + purchase_order_number: `000023` (string, nullable)
         + custom_fields (array[CustomFieldValue])
 

--- a/src/changes-backwards-compatible.apib
+++ b/src/changes-backwards-compatible.apib
@@ -8,6 +8,8 @@ We list all backwards-compatible additions here. These are currently available i
 
 - We added the `starts_on` field on `milestones.create`, `milestones.update` and `projects.create` for milestones
 
+- We added the `due_on` field on `projects.create` and `projects.update`, in order to be able to explicitly set a project's due date.
+
 #### May 2020
 
 - We no longer require all fields in `projects.update`, only the id remains required.


### PR DESCRIPTION
This PR adds the ability to set a project's end date on `projects.create` and `projects.update`. The field is already exposed in `projects.list` and `projects.info` because we calculate it behind the scenes as the last milestone's due date.

We're working on allowing to explicitly set the field.
