### PR TITLE
[IN-3055] document product_id

### DIFF
--- a/apiary.apib
+++ b/apiary.apib
@@ -2747,6 +2747,7 @@ Draft a new invoice.
                                 + Members
                                     + percentage - Values between 0 and 100
                         + product_category_id: `e2314517-3cab-4aa9-8471-450e73449041` (string, optional)
+                        + product_id: `d905ff57-e866-0f59-9d1e-1fd4538bfae1` (string, optional) - This purely informational and does not affect the invoice besides adding a reference to the product
         + invoice_date: `2016-02-04` (string, optional)
         + discounts (array, optional)
             (object)
@@ -2809,6 +2810,7 @@ Update an invoice.
                                 + Members
                                     + percentage - Values between 0 and 100
                         + product_category_id: `e2314517-3cab-4aa9-8471-450e73449041` (string, optional)
+                        + product_id: `d905ff57-e866-0f59-9d1e-1fd4538bfae1` (string, optional) - This purely informational and does not affect the invoice besides adding a reference to the product
         + invoice_date: `2016-02-04` (string, optional)
         + note: `Some comments about the invoice` (string, optional, nullable)
         + discounts (array, optional)

--- a/apiary.apib
+++ b/apiary.apib
@@ -2190,7 +2190,7 @@ Create a quotation.
                             + type (enum, required)
                                 + Members
                                     + percentage - Values between 0 and 100
-                        + product_id: `d905ff57-e866-0f59-9d1e-1fd4538bfae1` (string, optional) - This purely informational and does not affect the quotation besides adding a reference to the product
+                        + product_id: `d905ff57-e866-0f59-9d1e-1fd4538bfae1` (string, optional) - This is purely informational and does not affect the quotation besides adding a reference to the product
         + discounts (array, optional)
             + (object)
                 + value: 10 (number, required)
@@ -2235,7 +2235,7 @@ Update a quotation.
                             + type (enum, required)
                                 + Members
                                     + percentage - Values between 0 and 100
-                        + product_id: `d905ff57-e866-0f59-9d1e-1fd4538bfae1` (string, optional) - This purely informational and does not affect the quotation besides adding a reference to the product
+                        + product_id: `d905ff57-e866-0f59-9d1e-1fd4538bfae1` (string, optional) - This is purely informational and does not affect the quotation besides adding a reference to the product
         + discounts (array, optional)
             + (object)
                 + value: 10 (number, required)
@@ -2751,7 +2751,7 @@ Draft a new invoice.
                                 + Members
                                     + percentage - Values between 0 and 100
                         + product_category_id: `e2314517-3cab-4aa9-8471-450e73449041` (string, optional)
-                        + product_id: `d905ff57-e866-0f59-9d1e-1fd4538bfae1` (string, optional) - This purely informational and does not affect the invoice besides adding a reference to the product
+                        + product_id: `d905ff57-e866-0f59-9d1e-1fd4538bfae1` (string, optional) - This is purely informational and does not affect the invoice besides adding a reference to the product
         + invoice_date: `2016-02-04` (string, optional)
         + discounts (array, optional)
             (object)
@@ -2814,7 +2814,7 @@ Update an invoice.
                                 + Members
                                     + percentage - Values between 0 and 100
                         + product_category_id: `e2314517-3cab-4aa9-8471-450e73449041` (string, optional)
-                        + product_id: `d905ff57-e866-0f59-9d1e-1fd4538bfae1` (string, optional) - This purely informational and does not affect the invoice besides adding a reference to the product
+                        + product_id: `d905ff57-e866-0f59-9d1e-1fd4538bfae1` (string, optional) - This is purely informational and does not affect the invoice besides adding a reference to the product
         + invoice_date: `2016-02-04` (string, optional)
         + note: `Some comments about the invoice` (string, optional, nullable)
         + discounts (array, optional)

--- a/apiary.apib
+++ b/apiary.apib
@@ -2186,6 +2186,7 @@ Create a quotation.
                             + type (enum, required)
                                 + Members
                                     + percentage - Values between 0 and 100
+                        + product_id: `d905ff57-e866-0f59-9d1e-1fd4538bfae1` (string, optional) - This purely informational and does not affect the quotation besides adding a reference to the product
         + discounts (array, optional)
             + (object)
                 + value: 10 (number, required)
@@ -2230,6 +2231,7 @@ Update a quotation.
                             + type (enum, required)
                                 + Members
                                     + percentage - Values between 0 and 100
+                        + product_id: `d905ff57-e866-0f59-9d1e-1fd4538bfae1` (string, optional) - This purely informational and does not affect the quotation besides adding a reference to the product
         + discounts (array, optional)
             + (object)
                 + value: 10 (number, required)

--- a/apiary.apib
+++ b/apiary.apib
@@ -374,6 +374,10 @@ We list all backwards-compatible additions here. These are currently available i
 
 ### Latest
 
+- We added the `product_id` property to `quotations.create`, `quotations.update`, `invoices.draft` and `invoices.update`.
+
+### July 2020
+
 - We added `quotations.list`, `quotations.create` and `quotations.update`.
 
 ### June 2020

--- a/src/03-deals/quotations.apib
+++ b/src/03-deals/quotations.apib
@@ -144,7 +144,7 @@ Create a quotation.
                             + type (enum, required)
                                 + Members
                                     + percentage - Values between 0 and 100
-                        + product_id: `d905ff57-e866-0f59-9d1e-1fd4538bfae1` (string, optional) - This purely informational and does not affect the quotation besides adding a reference to the product
+                        + product_id: `d905ff57-e866-0f59-9d1e-1fd4538bfae1` (string, optional) - This is purely informational and does not affect the quotation besides adding a reference to the product
         + discounts (array, optional)
             + (object)
                 + value: 10 (number, required)
@@ -189,7 +189,7 @@ Update a quotation.
                             + type (enum, required)
                                 + Members
                                     + percentage - Values between 0 and 100
-                        + product_id: `d905ff57-e866-0f59-9d1e-1fd4538bfae1` (string, optional) - This purely informational and does not affect the quotation besides adding a reference to the product
+                        + product_id: `d905ff57-e866-0f59-9d1e-1fd4538bfae1` (string, optional) - This is purely informational and does not affect the quotation besides adding a reference to the product
         + discounts (array, optional)
             + (object)
                 + value: 10 (number, required)

--- a/src/03-deals/quotations.apib
+++ b/src/03-deals/quotations.apib
@@ -144,6 +144,7 @@ Create a quotation.
                             + type (enum, required)
                                 + Members
                                     + percentage - Values between 0 and 100
+                        + product_id: `d905ff57-e866-0f59-9d1e-1fd4538bfae1` (string, optional) - This purely informational and does not affect the quotation besides adding a reference to the product
         + discounts (array, optional)
             + (object)
                 + value: 10 (number, required)
@@ -188,6 +189,7 @@ Update a quotation.
                             + type (enum, required)
                                 + Members
                                     + percentage - Values between 0 and 100
+                        + product_id: `d905ff57-e866-0f59-9d1e-1fd4538bfae1` (string, optional) - This purely informational and does not affect the quotation besides adding a reference to the product
         + discounts (array, optional)
             + (object)
                 + value: 10 (number, required)

--- a/src/05-invoicing/invoices.apib
+++ b/src/05-invoicing/invoices.apib
@@ -267,7 +267,7 @@ Draft a new invoice.
                                 + Members
                                     + percentage - Values between 0 and 100
                         + product_category_id: `e2314517-3cab-4aa9-8471-450e73449041` (string, optional)
-                        + product_id: `d905ff57-e866-0f59-9d1e-1fd4538bfae1` (string, optional) - This purely informational and does not affect the invoice besides adding a reference to the product
+                        + product_id: `d905ff57-e866-0f59-9d1e-1fd4538bfae1` (string, optional) - This is purely informational and does not affect the invoice besides adding a reference to the product
         + invoice_date: `2016-02-04` (string, optional)
         + discounts (array, optional)
             (object)
@@ -330,7 +330,7 @@ Update an invoice.
                                 + Members
                                     + percentage - Values between 0 and 100
                         + product_category_id: `e2314517-3cab-4aa9-8471-450e73449041` (string, optional)
-                        + product_id: `d905ff57-e866-0f59-9d1e-1fd4538bfae1` (string, optional) - This purely informational and does not affect the invoice besides adding a reference to the product
+                        + product_id: `d905ff57-e866-0f59-9d1e-1fd4538bfae1` (string, optional) - This is purely informational and does not affect the invoice besides adding a reference to the product
         + invoice_date: `2016-02-04` (string, optional)
         + note: `Some comments about the invoice` (string, optional, nullable)
         + discounts (array, optional)

--- a/src/05-invoicing/invoices.apib
+++ b/src/05-invoicing/invoices.apib
@@ -267,6 +267,7 @@ Draft a new invoice.
                                 + Members
                                     + percentage - Values between 0 and 100
                         + product_category_id: `e2314517-3cab-4aa9-8471-450e73449041` (string, optional)
+                        + product_id: `d905ff57-e866-0f59-9d1e-1fd4538bfae1` (string, optional) - This purely informational and does not affect the invoice besides adding a reference to the product
         + invoice_date: `2016-02-04` (string, optional)
         + discounts (array, optional)
             (object)
@@ -329,6 +330,7 @@ Update an invoice.
                                 + Members
                                     + percentage - Values between 0 and 100
                         + product_category_id: `e2314517-3cab-4aa9-8471-450e73449041` (string, optional)
+                        + product_id: `d905ff57-e866-0f59-9d1e-1fd4538bfae1` (string, optional) - This purely informational and does not affect the invoice besides adding a reference to the product
         + invoice_date: `2016-02-04` (string, optional)
         + note: `Some comments about the invoice` (string, optional, nullable)
         + discounts (array, optional)

--- a/src/changes-backwards-compatible.apib
+++ b/src/changes-backwards-compatible.apib
@@ -6,6 +6,10 @@ We list all backwards-compatible additions here. These are currently available i
 
 ### Latest
 
+- We added the `product_id` property to `quotations.create`, `quotations.update`, `invoices.draft` and `invoices.update`.
+
+### July 2020
+
 - We added `quotations.list`, `quotations.create` and `quotations.update`.
 
 ### June 2020


### PR DESCRIPTION
Document that we will support adding product_id's through the api.

I felt like I had to clarify that price/description/extended description don't automatically get populated when providing a `product_id` but maybe it's a bit too verbose. Let me know.