### PR TITLE
 Added custom_fields to products.info response

### DIFF
--- a/src/05-invoicing/invoices.apib
+++ b/src/05-invoicing/invoices.apib
@@ -29,6 +29,7 @@ Get a list of invoices.
                 + field (enum, required)
                     + Members
                         + invoice_number
+                        + invoice_date
                 + order (enum, optional)
                     + Members
                         + asc

--- a/src/06-products/products.apib
+++ b/src/06-products/products.apib
@@ -43,6 +43,7 @@ Get details for a single product.
             + code: `COOK-DARKCHOC-42` (string, nullable)
             + purchase_price (Money, nullable, optional) - The purchase price will only be returned if you have access to it
             + selling_price (Money, nullable)
+            + custom_fields (array[CustomField])
 
 ### products.add [POST /products.add]
 


### PR DESCRIPTION
Same as companies.info, invoices.info, etc.
Edit: also allow sorting invoices.list by invoice_date (second commit).