### PR TITLE
Fix format for invoice discounts

### DIFF
--- a/apiary.apib
+++ b/apiary.apib
@@ -2759,7 +2759,7 @@ Draft a new invoice.
                         + product_id: `d905ff57-e866-0f59-9d1e-1fd4538bfae1` (string, optional)
         + invoice_date: `2016-02-04` (string, optional)
         + discounts (array, optional)
-            (object)
+            + (object)
                 + value: 10 (number, required)
                 + type (enum, required)
                     + Members
@@ -2823,7 +2823,7 @@ Update an invoice.
         + invoice_date: `2016-02-04` (string, optional)
         + note: `Some comments about the invoice` (string, optional, nullable)
         + discounts (array, optional)
-            (object)
+            + (object)
                 + value: 10 (number, required)
                 + type (enum, required)
                     + Members

--- a/src/05-invoicing/invoices.apib
+++ b/src/05-invoicing/invoices.apib
@@ -274,7 +274,7 @@ Draft a new invoice.
                         + product_id: `d905ff57-e866-0f59-9d1e-1fd4538bfae1` (string, optional)
         + invoice_date: `2016-02-04` (string, optional)
         + discounts (array, optional)
-            (object)
+            + (object)
                 + value: 10 (number, required)
                 + type (enum, required)
                     + Members
@@ -338,7 +338,7 @@ Update an invoice.
         + invoice_date: `2016-02-04` (string, optional)
         + note: `Some comments about the invoice` (string, optional, nullable)
         + discounts (array, optional)
-            (object)
+            + (object)
                 + value: 10 (number, required)
                 + type (enum, required)
                     + Members


### PR DESCRIPTION
There is a formatting error in the discounts for invoices.draft and invoices.update causing it to show the code.
![image](https://user-images.githubusercontent.com/1833617/90222793-123ab580-de0d-11ea-8dfa-158d86a9b51f.png)

Found by accident, it seems like it has always been like this 🤷 

### Manual check
- Run `make preview`
- Open the resulting `apiary.html` in your browser
- Go to invoices.draft and invoices.update. The (commercial) discounts section should look like a table instead of just the code