### PR TITLE
[INS-217] Add file to invoices.list/info

### DIFF
--- a/apiary.apib
+++ b/apiary.apib
@@ -2609,7 +2609,7 @@ Get a list of invoices.
                 + updated_at: `2016-02-05T16:44:33+00:00` (string)
                 + `web_url`: `https://app.teamleader.eu/invoice_detail.php?id=2aa4a6a9-9ce8-4851-a9b3-26aea2ea14c4` (string)
                 + pdf_file (object)
-                    + type: `file`
+                    + type: `file` (string)
                     + id: `39a02b79-b9a9-46e3-a44d-6c473b2fe350` (string)
 
 ### invoices.info [GET /invoices.info]
@@ -2728,7 +2728,7 @@ Get details for a single invoice.
                 + rate: 1.1234 (number)
             + expected_payment_method (ExpectedPaymentMethod, nullable)
             + pdf_file (object)
-                + type: `file`
+                + type: `file` (string)
                 + id: `39a02b79-b9a9-46e3-a44d-6c473b2fe350` (string)
             + custom_fields (array[CustomField])
             + created_at: `2016-02-04T16:44:33+00:00` (string)

--- a/apiary.apib
+++ b/apiary.apib
@@ -2608,6 +2608,9 @@ Get a list of invoices.
                 + created_at: `2016-02-04T16:44:33+00:00` (string)
                 + updated_at: `2016-02-05T16:44:33+00:00` (string)
                 + `web_url`: `https://app.teamleader.eu/invoice_detail.php?id=2aa4a6a9-9ce8-4851-a9b3-26aea2ea14c4` (string)
+                + pdf_file (object)
+                    + type: `file`
+                    + id: `39a02b79-b9a9-46e3-a44d-6c473b2fe350` (string)
 
 ### invoices.info [GET /invoices.info]
 
@@ -2724,6 +2727,9 @@ Get details for a single invoice.
                 + to: `EUR` (string)
                 + rate: 1.1234 (number)
             + expected_payment_method (ExpectedPaymentMethod, nullable)
+            + pdf_file (object)
+                + type: `file`
+                + id: `39a02b79-b9a9-46e3-a44d-6c473b2fe350` (string)
             + custom_fields (array[CustomField])
             + created_at: `2016-02-04T16:44:33+00:00` (string)
             + updated_at: `2016-02-05T16:44:33+00:00` (string)

--- a/apiary.apib
+++ b/apiary.apib
@@ -2608,7 +2608,7 @@ Get a list of invoices.
                 + created_at: `2016-02-04T16:44:33+00:00` (string)
                 + updated_at: `2016-02-05T16:44:33+00:00` (string)
                 + `web_url`: `https://app.teamleader.eu/invoice_detail.php?id=2aa4a6a9-9ce8-4851-a9b3-26aea2ea14c4` (string)
-                + pdf_file (object)
+                + file (object)
                     + type: `file` (string)
                     + id: `39a02b79-b9a9-46e3-a44d-6c473b2fe350` (string)
 
@@ -2727,7 +2727,7 @@ Get details for a single invoice.
                 + to: `EUR` (string)
                 + rate: 1.1234 (number)
             + expected_payment_method (ExpectedPaymentMethod, nullable)
-            + pdf_file (object)
+            + file (object)
                 + type: `file` (string)
                 + id: `39a02b79-b9a9-46e3-a44d-6c473b2fe350` (string)
             + custom_fields (array[CustomField])

--- a/apiary.apib
+++ b/apiary.apib
@@ -374,6 +374,10 @@ We list all backwards-compatible additions here. These are currently available i
 
 ### Latest
 
+- We added `file` to `invoices.list` and `invoices.info`.
+
+### September 2020
+
 - We added the `milestones.close` and `milestones.open` endpoints.
 - We added the `created_at` and `updated_at` fields to `quotations.list` and `quotations.info`. Please note that these fields are nullable and will only be filled in for future quotations.
 - We added the `discounts` field to `quotations.info`.
@@ -2608,7 +2612,7 @@ Get a list of invoices.
                 + created_at: `2016-02-04T16:44:33+00:00` (string)
                 + updated_at: `2016-02-05T16:44:33+00:00` (string)
                 + `web_url`: `https://app.teamleader.eu/invoice_detail.php?id=2aa4a6a9-9ce8-4851-a9b3-26aea2ea14c4` (string)
-                + file (object)
+                + file (object, nullable)
                     + type: `file` (string)
                     + id: `39a02b79-b9a9-46e3-a44d-6c473b2fe350` (string)
 
@@ -2727,7 +2731,7 @@ Get details for a single invoice.
                 + to: `EUR` (string)
                 + rate: 1.1234 (number)
             + expected_payment_method (ExpectedPaymentMethod, nullable)
-            + file (object)
+            + file (object, nullable)
                 + type: `file` (string)
                 + id: `39a02b79-b9a9-46e3-a44d-6c473b2fe350` (string)
             + custom_fields (array[CustomField])

--- a/src/05-invoicing/invoices.apib
+++ b/src/05-invoicing/invoices.apib
@@ -88,7 +88,7 @@ Get a list of invoices.
                 + created_at: `2016-02-04T16:44:33+00:00` (string)
                 + updated_at: `2016-02-05T16:44:33+00:00` (string)
                 + `web_url`: `https://app.teamleader.eu/invoice_detail.php?id=2aa4a6a9-9ce8-4851-a9b3-26aea2ea14c4` (string)
-                + pdf_file (object)
+                + file (object)
                     + type: `file` (string)
                     + id: `39a02b79-b9a9-46e3-a44d-6c473b2fe350` (string)
 
@@ -207,7 +207,7 @@ Get details for a single invoice.
                 + to: `EUR` (string)
                 + rate: 1.1234 (number)
             + expected_payment_method (ExpectedPaymentMethod, nullable)
-            + pdf_file (object)
+            + file (object)
                 + type: `file` (string)
                 + id: `39a02b79-b9a9-46e3-a44d-6c473b2fe350` (string)
             + custom_fields (array[CustomField])

--- a/src/05-invoicing/invoices.apib
+++ b/src/05-invoicing/invoices.apib
@@ -89,7 +89,7 @@ Get a list of invoices.
                 + updated_at: `2016-02-05T16:44:33+00:00` (string)
                 + `web_url`: `https://app.teamleader.eu/invoice_detail.php?id=2aa4a6a9-9ce8-4851-a9b3-26aea2ea14c4` (string)
                 + pdf_file (object)
-                    + type: `file`
+                    + type: `file` (string)
                     + id: `39a02b79-b9a9-46e3-a44d-6c473b2fe350` (string)
 
 ### invoices.info [GET /invoices.info]
@@ -208,7 +208,7 @@ Get details for a single invoice.
                 + rate: 1.1234 (number)
             + expected_payment_method (ExpectedPaymentMethod, nullable)
             + pdf_file (object)
-                + type: `file`
+                + type: `file` (string)
                 + id: `39a02b79-b9a9-46e3-a44d-6c473b2fe350` (string)
             + custom_fields (array[CustomField])
             + created_at: `2016-02-04T16:44:33+00:00` (string)

--- a/src/05-invoicing/invoices.apib
+++ b/src/05-invoicing/invoices.apib
@@ -88,6 +88,9 @@ Get a list of invoices.
                 + created_at: `2016-02-04T16:44:33+00:00` (string)
                 + updated_at: `2016-02-05T16:44:33+00:00` (string)
                 + `web_url`: `https://app.teamleader.eu/invoice_detail.php?id=2aa4a6a9-9ce8-4851-a9b3-26aea2ea14c4` (string)
+                + pdf_file (object)
+                    + type: `file`
+                    + id: `39a02b79-b9a9-46e3-a44d-6c473b2fe350` (string)
 
 ### invoices.info [GET /invoices.info]
 
@@ -204,6 +207,9 @@ Get details for a single invoice.
                 + to: `EUR` (string)
                 + rate: 1.1234 (number)
             + expected_payment_method (ExpectedPaymentMethod, nullable)
+            + pdf_file (object)
+                + type: `file`
+                + id: `39a02b79-b9a9-46e3-a44d-6c473b2fe350` (string)
             + custom_fields (array[CustomField])
             + created_at: `2016-02-04T16:44:33+00:00` (string)
             + updated_at: `2016-02-05T16:44:33+00:00` (string)

--- a/src/05-invoicing/invoices.apib
+++ b/src/05-invoicing/invoices.apib
@@ -88,7 +88,7 @@ Get a list of invoices.
                 + created_at: `2016-02-04T16:44:33+00:00` (string)
                 + updated_at: `2016-02-05T16:44:33+00:00` (string)
                 + `web_url`: `https://app.teamleader.eu/invoice_detail.php?id=2aa4a6a9-9ce8-4851-a9b3-26aea2ea14c4` (string)
-                + file (object)
+                + file (object, nullable)
                     + type: `file` (string)
                     + id: `39a02b79-b9a9-46e3-a44d-6c473b2fe350` (string)
 
@@ -207,7 +207,7 @@ Get details for a single invoice.
                 + to: `EUR` (string)
                 + rate: 1.1234 (number)
             + expected_payment_method (ExpectedPaymentMethod, nullable)
-            + file (object)
+            + file (object, nullable)
                 + type: `file` (string)
                 + id: `39a02b79-b9a9-46e3-a44d-6c473b2fe350` (string)
             + custom_fields (array[CustomField])

--- a/src/changes-backwards-compatible.apib
+++ b/src/changes-backwards-compatible.apib
@@ -6,6 +6,10 @@ We list all backwards-compatible additions here. These are currently available i
 
 ### Latest
 
+- We added `file` to `invoices.list` and `invoices.info`.
+
+### September 2020
+
 - We added the `milestones.close` and `milestones.open` endpoints.
 - We added the `created_at` and `updated_at` fields to `quotations.list` and `quotations.info`. Please note that these fields are nullable and will only be filled in for future quotations.
 - We added the `discounts` field to `quotations.info`.


### PR DESCRIPTION
https://teamleader.atlassian.net/browse/INS-217

Unfortunately invoices.download doesn't suit our use case, we need to show the pdf in the embedded pdf viewer using file_passthru.php

Implementation: https://github.com/teamleadercrm/core/pull/17840