### PR TITLE
Add filter for active companies and contacts

### DIFF
--- a/apiary.apib
+++ b/apiary.apib
@@ -1108,6 +1108,7 @@ Get a list of contacts.
             + term: `James` (string, optional) - Filters on first_name, last_name, email and telephone
             + updated_since: `2016-02-04T16:44:33+00:00` (string, optional)
             + tags: `expo`,`prospect` (array[string], optional) - Filters on contacts coupled to all given tags
+            + active: `true` (boolean, optional) - Filters on a contact's active status
         + page (Page, optional)
         + sort (array, optional)
             + (object)
@@ -1398,6 +1399,7 @@ Get a list of companies.
             + term: `Acme` (string, optional) - Filters on name, vat number, emails and telephones
             + updated_since: `2016-02-04T16:44:33+00:00` (string, optional)
             + tags: `expo`,`lead` (array[string], optional) - Filters on tag names
+            + active: `true` (boolean, optional) - Filters on a company's active status
         + page (Page, optional)
         + sort (array, optional)
             + (object)

--- a/src/02-crm/companies.apib
+++ b/src/02-crm/companies.apib
@@ -21,6 +21,7 @@ Get a list of companies.
             + term: `Acme` (string, optional) - Filters on name, vat number, emails and telephones
             + updated_since: `2016-02-04T16:44:33+00:00` (string, optional)
             + tags: `expo`,`lead` (array[string], optional) - Filters on tag names
+            + active: `true` (boolean, optional) - Filters on a company's active status
         + page (Page, optional)
         + sort (array, optional)
             + (object)

--- a/src/02-crm/contacts.apib
+++ b/src/02-crm/contacts.apib
@@ -22,6 +22,7 @@ Get a list of contacts.
             + term: `James` (string, optional) - Filters on first_name, last_name, email and telephone
             + updated_since: `2016-02-04T16:44:33+00:00` (string, optional)
             + tags: `expo`,`prospect` (array[string], optional) - Filters on contacts coupled to all given tags
+            + active: `true` (boolean, optional) - Filters on a contact's active status
         + page (Page, optional)
         + sort (array, optional)
             + (object)


### PR DESCRIPTION
Teamleader's import and interface allows you to deactivate companies and contacts, which is also visually shown very well in the interface:
![](https://i.imgur.com/wYMJLey.png)

However, there is no way to separate these inactive companies/contacts in the API, unless you decide to make a segment for them and use API v1...