### PR TITLE
Document that booked invoices can not be updated

### DIFF
--- a/apiary.apib
+++ b/apiary.apib
@@ -2914,7 +2914,7 @@ Draft a new invoice.
 
 ### invoices.update [POST /invoices.update]
 
-Update an invoice.
+Update a draft invoice. Booked invoices can not be updated.
 
 + Request (application/json)
 

--- a/apiary.apib
+++ b/apiary.apib
@@ -2914,7 +2914,7 @@ Draft a new invoice.
 
 ### invoices.update [POST /invoices.update]
 
-Update a draft invoice. Booked invoices can not be updated.
+Update a draft invoice. Booked invoices cannot be updated.
 
 + Request (application/json)
 

--- a/src/05-invoicing/invoices.apib
+++ b/src/05-invoicing/invoices.apib
@@ -305,7 +305,7 @@ Draft a new invoice.
 
 ### invoices.update [POST /invoices.update]
 
-Update an invoice.
+Update a draft invoice. Booked invoices can not be updated.
 
 + Request (application/json)
 

--- a/src/05-invoicing/invoices.apib
+++ b/src/05-invoicing/invoices.apib
@@ -305,7 +305,7 @@ Draft a new invoice.
 
 ### invoices.update [POST /invoices.update]
 
-Update a draft invoice. Booked invoices can not be updated.
+Update a draft invoice. Booked invoices cannot be updated.
 
 + Request (application/json)
 


### PR DESCRIPTION
We've got feedback that it wasn't clear that booked invoices can not be updated. Let's improve the documentation for the endpoint.