### PR TITLE
Document the field `unit_price` on `/invoices.draft` as required to reflect the reality

### DIFF
--- a/apiary.apib
+++ b/apiary.apib
@@ -2879,7 +2879,7 @@ Draft a new invoice.
                         + quantity: `3` (number, required)
                         + description: `An awesome product` (string, required)
                         + extended_description: `Some more information about this awesome product` (string, optional, nullable) - Uses Markdown formatting
-                        + unit_price (object)
+                        + unit_price (object, required)
                             + Include Money
                             + tax: `excluding` (enum, required)
                                 + Members

--- a/src/05-invoicing/invoices.apib
+++ b/src/05-invoicing/invoices.apib
@@ -270,7 +270,7 @@ Draft a new invoice.
                         + quantity: `3` (number, required)
                         + description: `An awesome product` (string, required)
                         + extended_description: `Some more information about this awesome product` (string, optional, nullable) - Uses Markdown formatting
-                        + unit_price (object)
+                        + unit_price (object, required)
                             + Include Money
                             + tax: `excluding` (enum, required)
                                 + Members


### PR DESCRIPTION
Superceeds https://github.com/teamleadercrm/api/pull/520

### Fixed
- Document the field `unit_price` on `/invoices.draft` as required to reflect the reality