### PR TITLE
TIDAL-460 timeTracking.list sorting

### DIFF
--- a/apiary.apib
+++ b/apiary.apib
@@ -4213,18 +4213,6 @@ Get a list of tracked time.
                         + project
                 + id: `2659dc4d-444b-4ced-b51c-b87591f604d7` (string, required)
         + page (Page, optional)
-        + sort (array, optional)
-            + (object)
-                + field (enum, required)
-                    + Members
-                        + started_on
-                + order (enum, optional)
-                    + Members
-                        + desc
-            + Default
-                + (object)
-                    + field: `started_on`
-                    + order: `desc`
 
 + Response 200 (application/json)
 

--- a/apiary.apib
+++ b/apiary.apib
@@ -4177,7 +4177,7 @@ Time tracking allows users to record time spent on tasks or projects and the typ
 
 ### timeTracking.list [GET /timeTracking.list]
 
-Get a list of tracked time.
+Get a list of tracked time. Per day, time tracking entries with an automatically generated start time are displayed first (duration time tracking), followed by entries with a user generated start and stop time (start-stop time tracking), sorted ascending by start time.
 
 + Request (application/json)
 

--- a/src/08-time-tracking/time-tracking.apib
+++ b/src/08-time-tracking/time-tracking.apib
@@ -4,7 +4,7 @@ Time tracking allows users to record time spent on tasks or projects and the typ
 
 ### timeTracking.list [GET /timeTracking.list]
 
-Get a list of tracked time.
+Get a list of tracked time. Per day, time tracking entries with an automatically generated start time are displayed first (duration time tracking), followed by entries with a user generated start and stop time (start-stop time tracking), sorted ascending by start time.
 
 + Request (application/json)
 

--- a/src/08-time-tracking/time-tracking.apib
+++ b/src/08-time-tracking/time-tracking.apib
@@ -40,18 +40,6 @@ Get a list of tracked time.
                         + project
                 + id: `2659dc4d-444b-4ced-b51c-b87591f604d7` (string, required)
         + page (Page, optional)
-        + sort (array, optional)
-            + (object)
-                + field (enum, required)
-                    + Members
-                        + started_on
-                + order (enum, optional)
-                    + Members
-                        + desc
-            + Default
-                + (object)
-                    + field: `started_on`
-                    + order: `desc`
 
 + Response 200 (application/json)
 


### PR DESCRIPTION
Removed sort parameter which was not used and added a description explaining the sorting on timeTracking.list