### PR TITLE
Add `ids` filter to `creditNotes.list` endpoint

### DIFF
--- a/apiary.apib
+++ b/apiary.apib
@@ -3131,6 +3131,7 @@ List credit notes
 
     + Attributes (object)
         + filter (object, optional)
+            + ids: `cb8da52a-ce89-4bf6-8f7e-8ee6cb85e3b5`,`f8a57a6f-dd1e-41a3-b8d3-428663f1d09e` (array[string], optional)
             + department_id: `080aac72-ff1a-4627-bfe3-146b6eee979c` (string, optional) - The ID of the department you wish to filter on.
             + updated_since: `2016-02-04T16:44:33+00:00` (string, optional)
         + page (Page, optional)

--- a/apiary.apib
+++ b/apiary.apib
@@ -403,6 +403,7 @@ We list all backwards-compatible additions here. These are currently available i
 - We added `status` on `companies.info`
 - We added `status` on `contacts.list`
 - We added `status` on `contacts.info`
+- We added `ids` to the filters on `creditNotes.list`
 
 ### September 2021
 

--- a/src/05-invoicing/credit-notes.apib
+++ b/src/05-invoicing/credit-notes.apib
@@ -12,6 +12,7 @@ List credit notes
 
     + Attributes (object)
         + filter (object, optional)
+            + ids: `cb8da52a-ce89-4bf6-8f7e-8ee6cb85e3b5`,`f8a57a6f-dd1e-41a3-b8d3-428663f1d09e` (array[string], optional)
             + department_id: `080aac72-ff1a-4627-bfe3-146b6eee979c` (string, optional) - The ID of the department you wish to filter on.
             + updated_since: `2016-02-04T16:44:33+00:00` (string, optional)
         + page (Page, optional)

--- a/src/changes-backwards-compatible.apib
+++ b/src/changes-backwards-compatible.apib
@@ -10,6 +10,7 @@ We list all backwards-compatible additions here. These are currently available i
 - We added `status` on `companies.info`
 - We added `status` on `contacts.list`
 - We added `status` on `contacts.info`
+- We added `ids` to the filters on `creditNotes.list`
 
 ### September 2021
 


### PR DESCRIPTION
This update allows users to filter credit notes returned by the `creditNotes.list` endpoint by a specified list of ids.