### PR TITLE
Update introduction

### DIFF
--- a/src/introduction.apib
+++ b/src/introduction.apib
@@ -1,4 +1,4 @@
-This is the new Teamleader API.  If you have any feedback, or are you missing functionality to support your use case? Let us know via [api@teamleader.eu](mailto:api@teamleader.eu).
+This is the documentation of the Teamleader API. If you have any feedback, or are you missing functionality to support your use case? Let us know via [api@teamleader.eu](mailto:api@teamleader.eu).
 
 ## AP-What?
 

--- a/src/introduction.apib
+++ b/src/introduction.apib
@@ -1,6 +1,4 @@
-This is the new Teamleader API. We will make additions and changes to this API, but don't worry; we will keep the documented endpoints backwards compatible for the lifetime of this major API version.
-
-Do you have any feedback, do you miss functionality to support your use case? Let us know via [api@teamleader.eu](mailto:api@teamleader.eu).
+This is the new Teamleader API.  If you have any feedback, or are you missing functionality to support your use case? Let us know via [api@teamleader.eu](mailto:api@teamleader.eu).
 
 ## AP-What?
 

--- a/src/introduction.apib
+++ b/src/introduction.apib
@@ -1,4 +1,4 @@
-This is the documentation of the Teamleader API. If you have any feedback, or are you missing functionality to support your use case? Let us know via [api@teamleader.eu](mailto:api@teamleader.eu).
+This is the documentation of the Teamleader Focus API. If you have any feedback, or are you missing functionality to support your use case? Let us know via [api@teamleader.eu](mailto:api@teamleader.eu).
 
 ## AP-What?
 


### PR DESCRIPTION
Remove the information about backwards compatibility during the lifetime of the current major version. It is too limiting.