### PR TITLE
`invoices.removePayment` and `invoices.removePayments`

### DIFF
--- a/apiary.apib
+++ b/apiary.apib
@@ -3139,7 +3139,7 @@ Register a payment for an invoice.
 
 ### invoices.removePayment [POST /invoices.removePayment]
 
-Remove a payment for a given invoice.
+Remove a payment for a given invoice. This will also trigger a re-rendering of the invoice PDF.
 
 + Request (application/json)
     + Attributes (object)

--- a/apiary.apib
+++ b/apiary.apib
@@ -397,6 +397,7 @@ We list all backwards-compatible additions here. These are currently available i
 
 ### August 2022
 
+- We added `invoices.removePayment` and `invoices.removePayments`.
 - We added `department_id` to the filters on `subscriptions.list`.
 
 ### July 2022
@@ -3133,6 +3134,27 @@ Register a payment for an invoice.
         + payment (object, required)
             + Include Money
         + paid_at: `2016-03-03T16:44:33+00:00` (string, required)
+
++ Response 204
+
+### invoices.removePayment [POST /invoices.removePayment]
+
+Remove a payment for a given invoice.
+
++ Request (application/json)
+    + Attributes (object)
+        + id: `179e1564-493b-4305-8c54-a34fc80920fc` (string, required)
+        + payment_id: `bb9589ec-6e08-0d5f-9b23-7be9b9c3ea2d` (string, required)
+
++ Response 204
+
+### invoices.removePayments [POST /invoices.removePayments]
+
+Marks an invoice as unpaid and removes all linked payments. This will also trigger a re-rendering of the invoice PDF.
+
++ Request (application/json)
+    + Attributes (object)
+        + id: `d885e5d5-bacb-4607-bde9-abc4a04a901b` (string, required)
 
 + Response 204
 

--- a/src/05-invoicing/invoices.apib
+++ b/src/05-invoicing/invoices.apib
@@ -416,7 +416,7 @@ Register a payment for an invoice.
 
 ### invoices.removePayment [POST /invoices.removePayment]
 
-Remove a payment for a given invoice.
+Remove a payment for a given invoice. This will also trigger a re-rendering of the invoice PDF.
 
 + Request (application/json)
     + Attributes (object)

--- a/src/05-invoicing/invoices.apib
+++ b/src/05-invoicing/invoices.apib
@@ -414,6 +414,16 @@ Register a payment for an invoice.
 
 + Response 204
 
+### invoices.removePayments [POST /invoices.removePayments]
+
+Marks an invoice as unpaid and removes all linked payments. This will also trigger a re-rendering of the invoice PDF.
+
++ Request (application/json)
+    + Attributes (object)
+        + id: `d885e5d5-bacb-4607-bde9-abc4a04a901b` (string, required)
+
++ Response 204
+
 ### invoices.credit [POST /invoices.credit]
 
 Credit an invoice completely.

--- a/src/05-invoicing/invoices.apib
+++ b/src/05-invoicing/invoices.apib
@@ -414,6 +414,17 @@ Register a payment for an invoice.
 
 + Response 204
 
+### invoices.removePayment [POST /invoices.removePayment]
+
+Remove a payment for a given invoice.
+
++ Request (application/json)
+    + Attributes (object)
+        + id: `179e1564-493b-4305-8c54-a34fc80920fc` (string, required)
+        + payment_id: `bb9589ec-6e08-0d5f-9b23-7be9b9c3ea2d` (string, required)
+
++ Response 204
+
 ### invoices.removePayments [POST /invoices.removePayments]
 
 Marks an invoice as unpaid and removes all linked payments. This will also trigger a re-rendering of the invoice PDF.

--- a/src/changes-backwards-compatible.apib
+++ b/src/changes-backwards-compatible.apib
@@ -6,6 +6,7 @@ We list all backwards-compatible additions here. These are currently available i
 
 ### August 2022
 
+- We added `invoices.removePayment` and `invoices.removePayments`.
 - We added `department_id` to the filters on `subscriptions.list`.
 
 ### July 2022


### PR DESCRIPTION
`invoices.removePayment` will remove one specific payment from an invoice.

`invoices.removePayments` will remove all payments from an invoice.

Both endpoints will regenerate the PDF, in case the invoice was already fully paid.