### PR TITLE
[FIX] Document the correct property for new sorting field

### DIFF
--- a/apiary.apib
+++ b/apiary.apib
@@ -432,7 +432,7 @@ We list all backwards-compatible additions here. These are currently available i
 
 ### November 2022
 
-- We added `invoice_number` as a sort field on `invoices.list`.
+- We added `invoice_date` as a sort field on `invoices.list`.
 
 ### October 2022
 

--- a/src/changes-backwards-compatible.apib
+++ b/src/changes-backwards-compatible.apib
@@ -6,7 +6,7 @@ We list all backwards-compatible additions here. These are currently available i
 
 ### November 2022
 
-- We added `invoice_number` as a sort field on `invoices.list`.
+- We added `invoice_date` as a sort field on `invoices.list`.
 
 ### October 2022
 


### PR DESCRIPTION
In https://github.com/teamleadercrm/api/pull/665 we added a new sorting field. But the documentation was referencing an incorrect field.