### PR TITLE
Update current API version

### DIFF
--- a/apiary.apib
+++ b/apiary.apib
@@ -768,7 +768,7 @@ This documentation only reflects the latest version of the API.
 If you need to make changes to your client or you want to make use of the latest feature, you might need to upgrade your API version.
 
 You can find your current API version, in the `X-Api-Version` header on any API response.
-The current latest version is **2021-09-01**.
+The current latest version is **2022-09-15**.
 
 After checking the API [changelog](#changelog) to see which endpoints work differently, you can upgrade your API version:
 

--- a/src/changes.apib
+++ b/src/changes.apib
@@ -38,7 +38,7 @@ This documentation only reflects the latest version of the API.
 If you need to make changes to your client or you want to make use of the latest feature, you might need to upgrade your API version.
 
 You can find your current API version, in the `X-Api-Version` header on any API response.
-The current latest version is **2021-09-01**.
+The current latest version is **2022-09-15**.
 
 After checking the API [changelog](#changelog) to see which endpoints work differently, you can upgrade your API version:
 


### PR DESCRIPTION
The current API version was not updated on `Changes & upgrades` when the new one was added to the changelog. 