### PR TITLE
Fix - Use h4 for changelog months

### DIFF
--- a/apiary.apib
+++ b/apiary.apib
@@ -432,7 +432,7 @@ We list all backwards-compatible additions here. These are currently available i
 
 - We added `ids` to the filters on `teams.list`.
 
-### March 2023
+#### March 2023
 
 - We added `customField`,`timeTracking` and `department` as allowed types on `migrate.id`.
 - We added `credit_note_date_before` and `credit_note_date_after` to the filters on `creditNotes.list`.

--- a/src/changes-backwards-compatible.apib
+++ b/src/changes-backwards-compatible.apib
@@ -14,7 +14,7 @@ We list all backwards-compatible additions here. These are currently available i
 
 - We added `ids` to the filters on `teams.list`.
 
-### March 2023
+#### March 2023
 
 - We added `customField`,`timeTracking` and `department` as allowed types on `migrate.id`.
 - We added `credit_note_date_before` and `credit_note_date_after` to the filters on `creditNotes.list`.


### PR DESCRIPTION
Noticed this:

![image](https://github.com/teamleadercrm/api/assets/11806615/9d1ac564-fa90-45b7-b22e-a65c42b0c92e)

Let's make it consistent