### PR TITLE
Update changes-backwards-incompatible.apib

### DIFF
--- a/src/changes-backwards-incompatible.apib
+++ b/src/changes-backwards-incompatible.apib
@@ -3,6 +3,10 @@
 
 We list all backwards-incompatible changes here. As described above, new additions and forwards-compatible changes don’t need a new API version and can be found [here](#additions).
 
+#### 2022-10-01
+
+- As of October 1st 2023, we expect all network clients to make use of TLS 1.2 when connecting to our infrastructure.
+
 #### 2022-09-15
 
 - The property `remark` has been renamed to `note` on:


### PR DESCRIPTION
added incompat warning about TLS 1.2