### PR TITLE
New projects: custom fields

### DIFF
--- a/apiary.apib
+++ b/apiary.apib
@@ -5423,7 +5423,7 @@ Returns all the information of a single project.
                         + `type`: `user` (string)
                         + `id`: `55d3707c-14dc-4b62-a072-e3f4c1413462` (string)
                     + `custom_rate` (Money)
-            + custom_fields (array[CustomField])
+            + custom_fields (array[CustomField]) - Auto-increment custom fields are not supported on projects.
 
 ### projects.create [POST /projects-v2/projects.create]
 
@@ -5482,7 +5482,7 @@ Create a new project. Only `title` is required. All the other fields are optiona
                 + `id`: `66abace2-62af-0836-a927-fe3f44b9b47b` (string, required)
         + `deal_ids`: `3709b7e9-7722-4d2d-a663-b480789bafe4`, `39fb2767-90e0-4fe4-9bac-a244bee6552c` (array[string], optional)
         + `quotation_ids`: `e8e8e969-2054-49ee-81d1-47453de2aebb`, `fc41c04f-1841-4238-a31b-42c48c57713e` (array[string], optional)
-        + custom_fields (array[CustomFieldValue], optional)
+        + `custom_fields` (array[CustomFieldValue], optional) - Auto-increment custom fields are not supported on projects.
 
 + Response 201 (application/json)
     + Attributes (object)
@@ -5536,7 +5536,7 @@ Update a project. All attributes except for `id` are optional. Providing `null` 
                 + `#C0C0C4` - Light grey
                 + `#82828C` - Grey
                 + `#1A1C20` - Dark grey
-        + custom_fields (array[CustomFieldValue], optional)
+        + `custom_fields` (array[CustomFieldValue], optional) - Auto-increment custom fields are not supported on projects.
 
 + Response 204
 

--- a/apiary.apib
+++ b/apiary.apib
@@ -427,7 +427,7 @@ We list all backwards-compatible additions here. These are currently available i
 (There is also a [list of backwards-incompatible upgrades](#changelog) available, but those only apply if you [upgrade your API version](#upgrading-your-api-version).)
 
 #### November 2023
-- We added `custom_fields` to `projects-v2/projects.info` and `projects-v2/projects.update`
+- We added `custom_fields` to `projects-v2/projects.info`, `projects-v2/projects.create` and `projects-v2/projects.update`
 
 #### October 2023
 - We added `late_fees` to `invoices.info` and `invoices.list`.
@@ -5482,6 +5482,7 @@ Create a new project. Only `title` is required. All the other fields are optiona
                 + `id`: `66abace2-62af-0836-a927-fe3f44b9b47b` (string, required)
         + `deal_ids`: `3709b7e9-7722-4d2d-a663-b480789bafe4`, `39fb2767-90e0-4fe4-9bac-a244bee6552c` (array[string], optional)
         + `quotation_ids`: `e8e8e969-2054-49ee-81d1-47453de2aebb`, `fc41c04f-1841-4238-a31b-42c48c57713e` (array[string], optional)
+        + custom_fields (array[CustomFieldValue], optional)
 
 + Response 201 (application/json)
     + Attributes (object)

--- a/apiary.apib
+++ b/apiary.apib
@@ -426,6 +426,9 @@ We consider the following changes to be backwards-incompatible:
 We list all backwards-compatible additions here. These are currently available in all published versions.
 (There is also a [list of backwards-incompatible upgrades](#changelog) available, but those only apply if you [upgrade your API version](#upgrading-your-api-version).)
 
+#### November 2023
+- We added `custom_fields` to `projects-v2/projects.info`
+
 #### October 2023
 - We added `late_fees` to `invoices.info` and `invoices.list`.
 - We added the `invoices.updateBooked` endpoint.
@@ -5420,6 +5423,7 @@ Returns all the information of a single project.
                         + `type`: `user` (string)
                         + `id`: `55d3707c-14dc-4b62-a072-e3f4c1413462` (string)
                     + `custom_rate` (Money)
+            + custom_fields (array[CustomField])
 
 ### projects.create [POST /projects-v2/projects.create]
 

--- a/apiary.apib
+++ b/apiary.apib
@@ -427,7 +427,7 @@ We list all backwards-compatible additions here. These are currently available i
 (There is also a [list of backwards-incompatible upgrades](#changelog) available, but those only apply if you [upgrade your API version](#upgrading-your-api-version).)
 
 #### November 2023
-- We added `custom_fields` to `projects-v2/projects.info`
+- We added `custom_fields` to `projects-v2/projects.info` and `projects-v2/projects.update`
 
 #### October 2023
 - We added `late_fees` to `invoices.info` and `invoices.list`.
@@ -5535,6 +5535,7 @@ Update a project. All attributes except for `id` are optional. Providing `null` 
                 + `#C0C0C4` - Light grey
                 + `#82828C` - Grey
                 + `#1A1C20` - Dark grey
+        + custom_fields (array[CustomFieldValue], optional)
 
 + Response 204
 

--- a/src/12-nextgen-projects/projects.apib
+++ b/src/12-nextgen-projects/projects.apib
@@ -277,6 +277,7 @@ Returns all the information of a single project.
                         + `type`: `user` (string)
                         + `id`: `55d3707c-14dc-4b62-a072-e3f4c1413462` (string)
                     + `custom_rate` (Money)
+            + custom_fields (array[CustomField])
 
 ### projects.create [POST /projects-v2/projects.create]
 

--- a/src/12-nextgen-projects/projects.apib
+++ b/src/12-nextgen-projects/projects.apib
@@ -389,6 +389,7 @@ Update a project. All attributes except for `id` are optional. Providing `null` 
                 + `#C0C0C4` - Light grey
                 + `#82828C` - Grey
                 + `#1A1C20` - Dark grey
+        + custom_fields (array[CustomFieldValue], optional)
 
 + Response 204
 

--- a/src/12-nextgen-projects/projects.apib
+++ b/src/12-nextgen-projects/projects.apib
@@ -277,7 +277,7 @@ Returns all the information of a single project.
                         + `type`: `user` (string)
                         + `id`: `55d3707c-14dc-4b62-a072-e3f4c1413462` (string)
                     + `custom_rate` (Money)
-            + custom_fields (array[CustomField])
+            + custom_fields (array[CustomField]) - Auto-increment custom fields are not supported on projects.
 
 ### projects.create [POST /projects-v2/projects.create]
 
@@ -336,7 +336,7 @@ Create a new project. Only `title` is required. All the other fields are optiona
                 + `id`: `66abace2-62af-0836-a927-fe3f44b9b47b` (string, required)
         + `deal_ids`: `3709b7e9-7722-4d2d-a663-b480789bafe4`, `39fb2767-90e0-4fe4-9bac-a244bee6552c` (array[string], optional)
         + `quotation_ids`: `e8e8e969-2054-49ee-81d1-47453de2aebb`, `fc41c04f-1841-4238-a31b-42c48c57713e` (array[string], optional)
-        + custom_fields (array[CustomFieldValue], optional)
+        + `custom_fields` (array[CustomFieldValue], optional) - Auto-increment custom fields are not supported on projects.
 
 + Response 201 (application/json)
     + Attributes (object)
@@ -390,7 +390,7 @@ Update a project. All attributes except for `id` are optional. Providing `null` 
                 + `#C0C0C4` - Light grey
                 + `#82828C` - Grey
                 + `#1A1C20` - Dark grey
-        + custom_fields (array[CustomFieldValue], optional)
+        + `custom_fields` (array[CustomFieldValue], optional) - Auto-increment custom fields are not supported on projects.
 
 + Response 204
 

--- a/src/12-nextgen-projects/projects.apib
+++ b/src/12-nextgen-projects/projects.apib
@@ -336,6 +336,7 @@ Create a new project. Only `title` is required. All the other fields are optiona
                 + `id`: `66abace2-62af-0836-a927-fe3f44b9b47b` (string, required)
         + `deal_ids`: `3709b7e9-7722-4d2d-a663-b480789bafe4`, `39fb2767-90e0-4fe4-9bac-a244bee6552c` (array[string], optional)
         + `quotation_ids`: `e8e8e969-2054-49ee-81d1-47453de2aebb`, `fc41c04f-1841-4238-a31b-42c48c57713e` (array[string], optional)
+        + custom_fields (array[CustomFieldValue], optional)
 
 + Response 201 (application/json)
     + Attributes (object)

--- a/src/changes-backwards-compatible.apib
+++ b/src/changes-backwards-compatible.apib
@@ -5,7 +5,7 @@ We list all backwards-compatible additions here. These are currently available i
 (There is also a [list of backwards-incompatible upgrades](#changelog) available, but those only apply if you [upgrade your API version](#upgrading-your-api-version).)
 
 #### November 2023
-- We added `custom_fields` to `projects-v2/projects.info` and `projects-v2/projects.update`
+- We added `custom_fields` to `projects-v2/projects.info`, `projects-v2/projects.create` and `projects-v2/projects.update`
 
 #### October 2023
 - We added `late_fees` to `invoices.info` and `invoices.list`.

--- a/src/changes-backwards-compatible.apib
+++ b/src/changes-backwards-compatible.apib
@@ -4,6 +4,9 @@
 We list all backwards-compatible additions here. These are currently available in all published versions.
 (There is also a [list of backwards-incompatible upgrades](#changelog) available, but those only apply if you [upgrade your API version](#upgrading-your-api-version).)
 
+#### November 2023
+- We added `custom_fields` to `projects-v2/projects.info`
+
 #### October 2023
 - We added `late_fees` to `invoices.info` and `invoices.list`.
 - We added the `invoices.updateBooked` endpoint.

--- a/src/changes-backwards-compatible.apib
+++ b/src/changes-backwards-compatible.apib
@@ -5,7 +5,7 @@ We list all backwards-compatible additions here. These are currently available i
 (There is also a [list of backwards-incompatible upgrades](#changelog) available, but those only apply if you [upgrade your API version](#upgrading-your-api-version).)
 
 #### November 2023
-- We added `custom_fields` to `projects-v2/projects.info`
+- We added `custom_fields` to `projects-v2/projects.info` and `projects-v2/projects.update`
 
 #### October 2023
 - We added `late_fees` to `invoices.info` and `invoices.list`.


### PR DESCRIPTION
This PR documents the ability to pass along custom field values to `/projects-v2/projects.create` and `/projects-v2/projects.update`, and to fetch those custom field values through `/projects-v2/projects.info`