### PR TITLE
Change type due to returning code: 405000

### DIFF
--- a/src/06-products/units-of-measure.apib
+++ b/src/06-products/units-of-measure.apib
@@ -1,6 +1,6 @@
 # Units of Measure [/unitsOfMeasure]
 
-### unitsOfMeasure.list [GET /unitsOfMeasure.list]
+### unitsOfMeasure.list [POST /unitsOfMeasure.list]
 
 Get a list of units of measure.
 


### PR DESCRIPTION
The method GET is not supported in your api. Only the post is supported in the API