### PR TITLE
`/emailTracking.create` | Now supports `nextgenProject` Subject Type

### DIFF
--- a/apiary.apib
+++ b/apiary.apib
@@ -447,6 +447,7 @@ We list all backwards-compatible additions here. These are currently available i
 - We now return the user's team(s) in `users.info` and `users.list` endpoints.
 - We added `nextgenProject` as a subject type to `files.upload`, `files.list` and `files.info`.
 - The `/customFieldDefinitions.list` endpoint can now filter custom field definitions by context and ids.
+- We added `nextgenProject` as a subject type to `emailTracking.create`.
 
 #### November 2023
 - We added the `calls.add`, `calls.list`, `calls.info` and `calls.complete` endpoints.
@@ -8834,3 +8835,4 @@ Fetch cloudPlatform url for type and id
 + `subscription`
 + `product`
 + `quotation`
++ `nextgenProject`

--- a/src/changes-backwards-compatible.apib
+++ b/src/changes-backwards-compatible.apib
@@ -25,6 +25,7 @@ We list all backwards-compatible additions here. These are currently available i
 - We now return the user's team(s) in `users.info` and `users.list` endpoints.
 - We added `nextgenProject` as a subject type to `files.upload`, `files.list` and `files.info`.
 - The `/customFieldDefinitions.list` endpoint can now filter custom field definitions by context and ids.
+- We added `nextgenProject` as a subject type to `emailTracking.create`.
 
 #### November 2023
 - We added the `calls.add`, `calls.list`, `calls.info` and `calls.complete` endpoints.

--- a/src/datastructures.apib
+++ b/src/datastructures.apib
@@ -477,3 +477,4 @@
 + `subscription`
 + `product`
 + `quotation`
++ `nextgenProject`


### PR DESCRIPTION
`/emailTracking.create` | Now supports `nextgenProject` Subject Type