### PR TITLE
Allow creating task for new project

### DIFF
--- a/apiary.apib
+++ b/apiary.apib
@@ -426,6 +426,9 @@ We consider the following changes to be backwards-incompatible:
 We list all backwards-compatible additions here. These are currently available in all published versions.
 (There is also a [list of backwards-incompatible upgrades](#changelog) available, but those only apply if you [upgrade your API version](#upgrading-your-api-version).)
 
+#### January 2024
+- We added `project_id` to the `tasks.create` endpoint.
+
 #### December 2023
 - The `dealPhases.list` endpoint can now filter phases by pipeline id.
 - We added `actions`, `requires_attention_after` and `probability` to `dealPhases.list`.

--- a/apiary.apib
+++ b/apiary.apib
@@ -7556,7 +7556,7 @@ Create a new task.
         + description (string)
         + due_on: `2016-02-04` (string, required)
         + work_type_id: `32665afd-1818-0ed3-9e18-a603a3a21b95` (string, required)
-        + milestone_id: `32665afd-1818-0ed3-9e18-a603a3a21b95` (string, optional)
+        + milestone_id: `32665afd-1818-0ed3-9e18-a603a3a21b95` (string, optional) - Only available for users that have access to the old projects module
         + deal_id: `32665afd-1818-0ed3-9e18-a603a3a21b95` (string, optional)
         + estimated_duration (object, optional)
             + unit (enum, required)

--- a/apiary.apib
+++ b/apiary.apib
@@ -7557,6 +7557,7 @@ Create a new task.
         + due_on: `2016-02-04` (string, required)
         + work_type_id: `32665afd-1818-0ed3-9e18-a603a3a21b95` (string, required)
         + milestone_id: `32665afd-1818-0ed3-9e18-a603a3a21b95` (string, optional) - Only available for users that have access to the old projects module
+        + project_id: `0185aa33-603c-7fd5-bf0d-5bd83d503b96` (string, optional) - Only available for users that have access to the new projects module
         + deal_id: `32665afd-1818-0ed3-9e18-a603a3a21b95` (string, optional)
         + estimated_duration (object, optional)
             + unit (enum, required)

--- a/src/08-tasks/tasks.apib
+++ b/src/08-tasks/tasks.apib
@@ -142,7 +142,7 @@ Create a new task.
         + description (string)
         + due_on: `2016-02-04` (string, required)
         + work_type_id: `32665afd-1818-0ed3-9e18-a603a3a21b95` (string, required)
-        + milestone_id: `32665afd-1818-0ed3-9e18-a603a3a21b95` (string, optional)
+        + milestone_id: `32665afd-1818-0ed3-9e18-a603a3a21b95` (string, optional) - Only available for users that have access to the old projects module
         + deal_id: `32665afd-1818-0ed3-9e18-a603a3a21b95` (string, optional)
         + estimated_duration (object, optional)
             + unit (enum, required)

--- a/src/08-tasks/tasks.apib
+++ b/src/08-tasks/tasks.apib
@@ -143,6 +143,7 @@ Create a new task.
         + due_on: `2016-02-04` (string, required)
         + work_type_id: `32665afd-1818-0ed3-9e18-a603a3a21b95` (string, required)
         + milestone_id: `32665afd-1818-0ed3-9e18-a603a3a21b95` (string, optional) - Only available for users that have access to the old projects module
+        + project_id: `0185aa33-603c-7fd5-bf0d-5bd83d503b96` (string, optional) - Only available for users that have access to the new projects module
         + deal_id: `32665afd-1818-0ed3-9e18-a603a3a21b95` (string, optional)
         + estimated_duration (object, optional)
             + unit (enum, required)

--- a/src/changes-backwards-compatible.apib
+++ b/src/changes-backwards-compatible.apib
@@ -4,6 +4,9 @@
 We list all backwards-compatible additions here. These are currently available in all published versions.
 (There is also a [list of backwards-incompatible upgrades](#changelog) available, but those only apply if you [upgrade your API version](#upgrading-your-api-version).)
 
+#### January 2024
+- We added `project_id` to the `tasks.create` endpoint.
+
 #### December 2023
 - The `dealPhases.list` endpoint can now filter phases by pipeline id.
 - We added `actions`, `requires_attention_after` and `probability` to `dealPhases.list`.


### PR DESCRIPTION
This PR documents the addition of the `project_id` property in the `/tasks.create` endpoint for users with access to the new projects module.