### PR TITLE
`work_type` instead of `task_type`

### DIFF
--- a/apiary.apib
+++ b/apiary.apib
@@ -426,6 +426,10 @@ We consider the following changes to be backwards-incompatible:
 We list all backwards-compatible additions here. These are currently available in all published versions.
 (There is also a [list of backwards-incompatible upgrades](#changelog) available, but those only apply if you [upgrade your API version](#upgrading-your-api-version).)
 
+#### January 2024
+- We renamed `task_type` and `task_type_id` to `work_type` and `work_type_id` in `projects-v2/tasks.list`, `projects-v2/tasks.info`, `projects-v2/tasks.create` and `projects-v2/tasks.update`. The old names are still supported, but deprecated.
+- We replaced `task_type_rate` with `work_type_rate` in `projects-v2/tasks.list`, `projects-v2/tasks.info`, `projects-v2/tasks.create` and `projects-v2/tasks.update`. `task_type_rate` was never used.
+
 #### December 2023
 - The `dealPhases.list` endpoint can now filter phases by pipeline id.
 - We added `actions`, `requires_attention_after` and `probability` to `dealPhases.list`.
@@ -6853,7 +6857,10 @@ Lists all the tasks that match the optional filters provided.
                 + `group` (object, nullable) - If `null`, the task is not in any group.
                     + `type`: `nextgenProjectGroup` (string)
                     + `id`: `eab232c6-49b2-4b7e-a977-5e1148dad471` (string)
-                + `task_type` (object, nullable) - If null, the task does not have a specific work type.
+                + `work_type` (object, nullable) - If null, the task does not have a specific work type.
+                    + `type`: `workType` (string)
+                    + `id`: `0f517e20-2e76-4684-8d6c-3334f6d7148c` (string)
+                + `task_type` (object, nullable) - DEPRECATED - Use `work_type` instead.
                     + `type`: `workType` (string)
                     + `id`: `0f517e20-2e76-4684-8d6c-3334f6d7148c` (string)
                 + `status`: `in_progress` (enum[string])
@@ -6866,7 +6873,7 @@ Lists all the tasks that match the optional filters provided.
                 + `billing_method`: `user_rate` (enum[string])
                     + Members
                         + `user_rate` - Based on the rate of the user who tracked time and the amount of time tracked.
-                        + `task_type_rate` - Based on the rate of the task type and the amount of time tracked.
+                        + `work_type_rate` - Based on the rate of the work type and the amount of time tracked.
                         + `custom_rate` - Based on the custom rate set on the task and the amount of time tracked.
                         + `fixed_price`
                         + `parent_fixed_price` - The parent project or group must be `fixed_price`.
@@ -6931,7 +6938,10 @@ Returns all the information for one task.
             + `group` (object, nullable) - If `null`, the task is not in any group.
                 + `type`: `nextgenProjectGroup` (string)
                 + `id`: `eab232c6-49b2-4b7e-a977-5e1148dad471` (string)
-            + `task_type` (object, nullable) - If null, the task does not have a specific work type.
+            + `work_type` (object, nullable) - If null, the task does not have a specific work type.
+                + `type`: `workType` (string)
+                + `id`: `0f517e20-2e76-4684-8d6c-3334f6d7148c` (string)
+            + `task_type` (object, nullable) - DEPRECATED - Use `work_type` instead.
                 + `type`: `workType` (string)
                 + `id`: `0f517e20-2e76-4684-8d6c-3334f6d7148c` (string)
             + `status`: `in_progress` (enum[string])
@@ -6945,7 +6955,7 @@ Returns all the information for one task.
             + `billing_method`: `user_rate` (enum[string])
                 + Members
                     + `user_rate` - Based on the rate of the user who tracked time and the amount of time tracked.
-                    + `task_type_rate` - Based on the rate of the task type and the amount of time tracked.
+                    + `work_type_rate` - Based on the rate of the work type and the amount of time tracked.
                     + `custom_rate` - Based on the custom rate set on the task and the amount of time tracked.
                     + `fixed_price`
                     + `parent_fixed_price` - The parent project or group must be `fixed_price`.
@@ -7001,18 +7011,19 @@ Create a task. All properties except for `title` and `project_id` are optional.
         + `project_id`: `49b403be-a32e-0901-9b1c-25214f9027c6` (string, required)
         + `title`: `My task` (string, required)
         + `group_id`: `0185968b-2c9e-73fd-9ce1-a12c0979783b` (string) - If omitted the task is not added to a group.
-        + `task_type_id`: `0f517e20-2e76-4684-8d6c-3334f6d7148c` (string, optional) - Cannot be null if `billing_method` is `task_type_rate`.
+        + `work_type_id`: `0f517e20-2e76-4684-8d6c-3334f6d7148c` (string, optional) - Cannot be null if `billing_method` is `task_type_rate`.
+        + `task_type_id`: `0f517e20-2e76-4684-8d6c-3334f6d7148c` (string, optional) - DEPRECATED - Use `work_type_id` instead.
         + `description`: `But nothing is any good without you cause baby you are my centerpiece` (string, optional)
         + `billing_method`: `fixed_price` (enum[string], optional)
             + Members
                 + `user_rate` - Based on the rate of the user who tracked time and the amount of time tracked.
-                + `task_type_rate` - Based on the rate of the task type and the amount of time tracked.
+                + `work_type_rate` - Based on the rate of the work type and the amount of time tracked.
                 + `custom_rate` - Based on the custom rate set on the task and the amount of time tracked.
                 + `fixed_price`
                 + `parent_fixed_price` - The parent project or group must be `fixed_price`.
                 + `non_billable`
         + `fixed_price` (Money, optional) - Can only be provided if `billing_method` is `fixed_price`.
-        + `external_budget` (Money, optional) - Also known as "price budget". Value set by user to compare with price. Can only be provided if `billing_method` is `user_rate`, `task_type_rate`, or `custom_rate`.
+        + `external_budget` (Money, optional) - Also known as "price budget". Value set by user to compare with price. Can only be provided if `billing_method` is `user_rate`, `work_type_rate`, or `custom_rate`.
         + `internal_budget` (Money, optional) - Also known as "cost budget". Value set by user to compare with cost.
         + `custom_rate` (Money, optional) - Can only be provided if `billing_method` is `custom_rate`.
         + `start_date`: `2023-01-18` (string, optional)
@@ -7045,7 +7056,8 @@ Update a task. All attributes except for `id` are optional. Providing `null` wil
 + Request (application/json)
     + Attributes (object)
         + `id`: `ff19a113-50ba-4afc-9fff-2e5c5c5a5485` (string, required)
-        + `task_type_id`: `0f517e20-2e76-4684-8d6c-3334f6d7148c` (string, nullable, optional) - Cannot be null if `billing_method` is `task_type_rate`.
+        + `work_type_id`: `0f517e20-2e76-4684-8d6c-3334f6d7148c` (string, nullable, optional) - Cannot be null if `billing_method` is `work_type_rate`.
+        + `task_type_id`: `0f517e20-2e76-4684-8d6c-3334f6d7148c` (string, nullable, optional) - DEPRECATED - Use `work_type_id` instead.
         + `status`: `on_hold` (enum[string], optional)
             + Members
                 + `to_do`
@@ -7057,13 +7069,13 @@ Update a task. All attributes except for `id` are optional. Providing `null` wil
         + `billing_method`: `fixed_price` (enum[string], optional)
             + Members
                 + `user_rate` - Based on the rate of the user who tracked time and the amount of time tracked.
-                + `task_type_rate` - Based on the rate of the task type and the amount of time tracked.
+                + `work_type_rate` - Based on the rate of the work type and the amount of time tracked.
                 + `custom_rate` - Based on the custom rate set on the task and the amount of time tracked.
                 + `fixed_price`
                 + `parent_fixed_price` - The parent project or group must be `fixed_price`.
                 + `non_billable`
         + `fixed_price` (Money, nullable, optional) - Can only be provided if `billing_method` is `fixed_price`.
-        + `external_budget` (Money, nullable, optional) - Also known as "price budget". Value set by user to compare with price. Can only be provided if `billing_method` is `user_rate`, `task_type_rate`, or `custom_rate`.
+        + `external_budget` (Money, nullable, optional) - Also known as "price budget". Value set by user to compare with price. Can only be provided if `billing_method` is `user_rate`, `work_type_rate`, or `custom_rate`.
         + `internal_budget` (Money, nullable, optional) - Also known as "cost budget". Value set by user to compare with cost.
         + `custom_rate` (Money, nullable, optional) - Can only be provided if `billing_method` is `custom_rate`.
         + `start_date`: `2023-01-18` (string, nullable, optional)

--- a/src/12-nextgen-projects/tasks.apib
+++ b/src/12-nextgen-projects/tasks.apib
@@ -24,7 +24,10 @@ Lists all the tasks that match the optional filters provided.
                 + `group` (object, nullable) - If `null`, the task is not in any group.
                     + `type`: `nextgenProjectGroup` (string)
                     + `id`: `eab232c6-49b2-4b7e-a977-5e1148dad471` (string)
-                + `task_type` (object, nullable) - If null, the task does not have a specific work type.
+                + `work_type` (object, nullable) - If null, the task does not have a specific work type.
+                    + `type`: `workType` (string)
+                    + `id`: `0f517e20-2e76-4684-8d6c-3334f6d7148c` (string)
+                + `task_type` (object, nullable) - DEPRECATED - Use `work_type` instead.
                     + `type`: `workType` (string)
                     + `id`: `0f517e20-2e76-4684-8d6c-3334f6d7148c` (string)
                 + `status`: `in_progress` (enum[string])
@@ -37,7 +40,7 @@ Lists all the tasks that match the optional filters provided.
                 + `billing_method`: `user_rate` (enum[string])
                     + Members
                         + `user_rate` - Based on the rate of the user who tracked time and the amount of time tracked.
-                        + `task_type_rate` - Based on the rate of the task type and the amount of time tracked.
+                        + `work_type_rate` - Based on the rate of the work type and the amount of time tracked.
                         + `custom_rate` - Based on the custom rate set on the task and the amount of time tracked.
                         + `fixed_price`
                         + `parent_fixed_price` - The parent project or group must be `fixed_price`.
@@ -102,7 +105,10 @@ Returns all the information for one task.
             + `group` (object, nullable) - If `null`, the task is not in any group.
                 + `type`: `nextgenProjectGroup` (string)
                 + `id`: `eab232c6-49b2-4b7e-a977-5e1148dad471` (string)
-            + `task_type` (object, nullable) - If null, the task does not have a specific work type.
+            + `work_type` (object, nullable) - If null, the task does not have a specific work type.
+                + `type`: `workType` (string)
+                + `id`: `0f517e20-2e76-4684-8d6c-3334f6d7148c` (string)
+            + `task_type` (object, nullable) - DEPRECATED - Use `work_type` instead.
                 + `type`: `workType` (string)
                 + `id`: `0f517e20-2e76-4684-8d6c-3334f6d7148c` (string)
             + `status`: `in_progress` (enum[string])
@@ -116,7 +122,7 @@ Returns all the information for one task.
             + `billing_method`: `user_rate` (enum[string])
                 + Members
                     + `user_rate` - Based on the rate of the user who tracked time and the amount of time tracked.
-                    + `task_type_rate` - Based on the rate of the task type and the amount of time tracked.
+                    + `work_type_rate` - Based on the rate of the work type and the amount of time tracked.
                     + `custom_rate` - Based on the custom rate set on the task and the amount of time tracked.
                     + `fixed_price`
                     + `parent_fixed_price` - The parent project or group must be `fixed_price`.
@@ -172,18 +178,19 @@ Create a task. All properties except for `title` and `project_id` are optional.
         + `project_id`: `49b403be-a32e-0901-9b1c-25214f9027c6` (string, required)
         + `title`: `My task` (string, required)
         + `group_id`: `0185968b-2c9e-73fd-9ce1-a12c0979783b` (string) - If omitted the task is not added to a group.
-        + `task_type_id`: `0f517e20-2e76-4684-8d6c-3334f6d7148c` (string, optional) - Cannot be null if `billing_method` is `task_type_rate`.
+        + `work_type_id`: `0f517e20-2e76-4684-8d6c-3334f6d7148c` (string, optional) - Cannot be null if `billing_method` is `task_type_rate`.
+        + `task_type_id`: `0f517e20-2e76-4684-8d6c-3334f6d7148c` (string, optional) - DEPRECATED - Use `work_type_id` instead.
         + `description`: `But nothing is any good without you cause baby you are my centerpiece` (string, optional)
         + `billing_method`: `fixed_price` (enum[string], optional)
             + Members
                 + `user_rate` - Based on the rate of the user who tracked time and the amount of time tracked.
-                + `task_type_rate` - Based on the rate of the task type and the amount of time tracked.
+                + `work_type_rate` - Based on the rate of the work type and the amount of time tracked.
                 + `custom_rate` - Based on the custom rate set on the task and the amount of time tracked.
                 + `fixed_price`
                 + `parent_fixed_price` - The parent project or group must be `fixed_price`.
                 + `non_billable`
         + `fixed_price` (Money, optional) - Can only be provided if `billing_method` is `fixed_price`.
-        + `external_budget` (Money, optional) - Also known as "price budget". Value set by user to compare with price. Can only be provided if `billing_method` is `user_rate`, `task_type_rate`, or `custom_rate`.
+        + `external_budget` (Money, optional) - Also known as "price budget". Value set by user to compare with price. Can only be provided if `billing_method` is `user_rate`, `work_type_rate`, or `custom_rate`.
         + `internal_budget` (Money, optional) - Also known as "cost budget". Value set by user to compare with cost.
         + `custom_rate` (Money, optional) - Can only be provided if `billing_method` is `custom_rate`.
         + `start_date`: `2023-01-18` (string, optional)
@@ -216,7 +223,8 @@ Update a task. All attributes except for `id` are optional. Providing `null` wil
 + Request (application/json)
     + Attributes (object)
         + `id`: `ff19a113-50ba-4afc-9fff-2e5c5c5a5485` (string, required)
-        + `task_type_id`: `0f517e20-2e76-4684-8d6c-3334f6d7148c` (string, nullable, optional) - Cannot be null if `billing_method` is `task_type_rate`.
+        + `work_type_id`: `0f517e20-2e76-4684-8d6c-3334f6d7148c` (string, nullable, optional) - Cannot be null if `billing_method` is `work_type_rate`.
+        + `task_type_id`: `0f517e20-2e76-4684-8d6c-3334f6d7148c` (string, nullable, optional) - DEPRECATED - Use `work_type_id` instead.
         + `status`: `on_hold` (enum[string], optional)
             + Members
                 + `to_do`
@@ -228,13 +236,13 @@ Update a task. All attributes except for `id` are optional. Providing `null` wil
         + `billing_method`: `fixed_price` (enum[string], optional)
             + Members
                 + `user_rate` - Based on the rate of the user who tracked time and the amount of time tracked.
-                + `task_type_rate` - Based on the rate of the task type and the amount of time tracked.
+                + `work_type_rate` - Based on the rate of the work type and the amount of time tracked.
                 + `custom_rate` - Based on the custom rate set on the task and the amount of time tracked.
                 + `fixed_price`
                 + `parent_fixed_price` - The parent project or group must be `fixed_price`.
                 + `non_billable`
         + `fixed_price` (Money, nullable, optional) - Can only be provided if `billing_method` is `fixed_price`.
-        + `external_budget` (Money, nullable, optional) - Also known as "price budget". Value set by user to compare with price. Can only be provided if `billing_method` is `user_rate`, `task_type_rate`, or `custom_rate`.
+        + `external_budget` (Money, nullable, optional) - Also known as "price budget". Value set by user to compare with price. Can only be provided if `billing_method` is `user_rate`, `work_type_rate`, or `custom_rate`.
         + `internal_budget` (Money, nullable, optional) - Also known as "cost budget". Value set by user to compare with cost.
         + `custom_rate` (Money, nullable, optional) - Can only be provided if `billing_method` is `custom_rate`.
         + `start_date`: `2023-01-18` (string, nullable, optional)

--- a/src/changes-backwards-compatible.apib
+++ b/src/changes-backwards-compatible.apib
@@ -5,8 +5,8 @@ We list all backwards-compatible additions here. These are currently available i
 (There is also a [list of backwards-incompatible upgrades](#changelog) available, but those only apply if you [upgrade your API version](#upgrading-your-api-version).)
 
 #### January 2024
-- We renamed `task_type` and `task_type_id` to `work_type` and `work_type_id` in `tasks.list`, `tasks.info`, `tasks.create` and `tasks.update`. The old names are still supported, but deprecated.
-- We replaced `task_type_rate` with `work_type_rate` in `tasks.list`, `tasks.info`, `tasks.create` and `tasks.update`. `task_type_rate` was never used.
+- We renamed `task_type` and `task_type_id` to `work_type` and `work_type_id` in `projects-v2/tasks.list`, `projects-v2/tasks.info`, `projects-v2/tasks.create` and `projects-v2/tasks.update`. The old names are still supported, but deprecated.
+- We replaced `task_type_rate` with `work_type_rate` in `projects-v2/tasks.list`, `projects-v2/tasks.info`, `projects-v2/tasks.create` and `projects-v2/tasks.update`. `task_type_rate` was never used.
 
 #### December 2023
 - The `dealPhases.list` endpoint can now filter phases by pipeline id.

--- a/src/changes-backwards-compatible.apib
+++ b/src/changes-backwards-compatible.apib
@@ -4,6 +4,10 @@
 We list all backwards-compatible additions here. These are currently available in all published versions.
 (There is also a [list of backwards-incompatible upgrades](#changelog) available, but those only apply if you [upgrade your API version](#upgrading-your-api-version).)
 
+#### January 2024
+- We renamed `task_type` and `task_type_id` to `work_type` and `work_type_id` in `tasks.list`, `tasks.info`, `tasks.create` and `tasks.update`. The old names are still supported, but deprecated.
+- We replaced `task_type_rate` with `work_type_rate` in `tasks.list`, `tasks.info`, `tasks.create` and `tasks.update`. `task_type_rate` was never used.
+
 #### December 2023
 - The `dealPhases.list` endpoint can now filter phases by pipeline id.
 - We added `actions`, `requires_attention_after` and `probability` to `dealPhases.list`.


### PR DESCRIPTION
Let's make the API more consistent. In order not to break integrations using `task_type`, we will keep on accepting `task_type_id` and serving `task_type` until further notice.