### PR TITLE
Fix expiration time of access tokens

### DIFF
--- a/src/authentication.apib
+++ b/src/authentication.apib
@@ -39,7 +39,7 @@ If the user denies your integration, he will be redirected to the `redirect_uri`
 
 ### Obtaining access tokens
 
-After receiving the authorization code from the previous step, an access token can be requested to make API calls. Note that authorization codes can only be exchanged for an access token once and expire 10 minutes after issuance. To exchange the code for an access token, send an HTTP POST request to the following endpoint:
+After receiving the authorization code from the previous step, an access token can be requested to make API calls. Note that authorization codes can only be exchanged for an access token once and expires one hour after issuance. To exchange the code for an access token, send an HTTP POST request to the following endpoint:
 
 `https://focus.teamleader.eu/oauth2/access_token`
 


### PR DESCRIPTION
Hey 👋

I'm currently working an custom Teamleader integration for one of our clients and noticed a small bug in the authentication documentation.

As per the official [OAuth 2.0 RFC](https://www.rfc-editor.org/rfc/rfc6749#section-4.2.2) documentation, the `expires_in` denotes the the lifetime in seconds of the access token. As the access_token returned by the Teamleader when obtaining an access token is 3600 seconds, this expiration time of the access token is one hour, rather than 10 minutes. 
