### PR TITLE
[CON-38] Document the public related companies and contacts includes on the companies.info endpoint

### DIFF
--- a/apiary.apib
+++ b/apiary.apib
@@ -435,6 +435,7 @@ We list all backwards-compatible additions here. These are currently available i
 - We added `deal` to `calls.list` and `calls.info`.
 - We added `task.created`, `task.updated`, `task.completed`, `task.deleted` types to supported Webhook types.
 - We added `contact.updatedLinkToCompany` to supported Webhook types.
+- We added `includes` to the `companies.info` endpoint.
 
 #### January 2024
 - We renamed `task_type` and `task_type_id` to `work_type` and `work_type_id` in `projects-v2/tasks.list`, `projects-v2/tasks.info`, `projects-v2/tasks.create` and `projects-v2/tasks.update`. The old names are still supported, but deprecated.
@@ -2233,6 +2234,7 @@ Get details for a single company.
 
     + Attributes (object)
         + id: `e8d31ae7-8258-4fcd-9b2d-78f41b0aa5d5` (string, required)
+        + includes: `related_companies,related_contacts` (string, optional) - when used, the response will include `related_companies` and/or `related_contacts`
 
 + Response 200 (application/json)
 
@@ -2284,6 +2286,18 @@ Get details for a single company.
             + tags: prospect, expo (array[string])
             + custom_fields (array[CustomField])
             + marketing_mails_consent: false (boolean)
+            + `related_companies` (array) - Only included with request parameter `includes=related_companies`
+                + (object)
+                    + type: `company` (string)
+                    + id: `f29abf48-337d-44b4-aad4-585f5277a456` (string)
+            + `related_contacts` (array) - Only included with request parameter `includes=related_contacts`
+                + (object)
+                    + type: `contact` (string)
+                    + id: `f29abf48-337d-44b4-aad4-585f5277a456` (string)
+                    + position: `Developer` (string, nullable)
+                    + secondary_position: `Technical lead` (string, nullable)
+                    + division: `Engineering` (string, nullable)
+                    + is_decision_maker: false (boolean)
 
 ### companies.add [POST /companies.add]
 

--- a/src/02-crm/companies.apib
+++ b/src/02-crm/companies.apib
@@ -92,6 +92,7 @@ Get details for a single company.
 
     + Attributes (object)
         + id: `e8d31ae7-8258-4fcd-9b2d-78f41b0aa5d5` (string, required)
+        + includes: `related_companies,related_contacts` (string, optional) - when used, the response will include `related_companies` and/or `related_contacts`
 
 + Response 200 (application/json)
 
@@ -143,6 +144,18 @@ Get details for a single company.
             + tags: prospect, expo (array[string])
             + custom_fields (array[CustomField])
             + marketing_mails_consent: false (boolean)
+            + `related_companies` (array) - Only included with request parameter `includes=related_companies`
+                + (object)
+                    + type: `company` (string)
+                    + id: `f29abf48-337d-44b4-aad4-585f5277a456` (string)
+            + `related_contacts` (array) - Only included with request parameter `includes=related_contacts`
+                + (object)
+                    + type: `contact` (string)
+                    + id: `f29abf48-337d-44b4-aad4-585f5277a456` (string)
+                    + position: `Developer` (string, nullable)
+                    + secondary_position: `Technical lead` (string, nullable)
+                    + division: `Engineering` (string, nullable)
+                    + is_decision_maker: false (boolean)
 
 ### companies.add [POST /companies.add]
 

--- a/src/changes-backwards-compatible.apib
+++ b/src/changes-backwards-compatible.apib
@@ -13,6 +13,7 @@ We list all backwards-compatible additions here. These are currently available i
 - We added `deal` to `calls.list` and `calls.info`.
 - We added `task.created`, `task.updated`, `task.completed`, `task.deleted` types to supported Webhook types.
 - We added `contact.updatedLinkToCompany` to supported Webhook types.
+- We added `includes` to the `companies.info` endpoint.
 
 #### January 2024
 - We renamed `task_type` and `task_type_id` to `work_type` and `work_type_id` in `projects-v2/tasks.list`, `projects-v2/tasks.info`, `projects-v2/tasks.create` and `projects-v2/tasks.update`. The old names are still supported, but deprecated.


### PR DESCRIPTION
### Description

- Document the public related companies and contacts includes on the companies.info endpoint

Documented public includes:

- related_companies
- related_contacts

### Manual check

- Clone this repo
- Run `make preview`
- Open the generated html file
- Browse to the documentation for this endpoint, and verify if it matches the response
