### PR TITLE
[CON-29] Document the external_rate includes on /users.info

### DIFF
--- a/apiary.apib
+++ b/apiary.apib
@@ -1344,9 +1344,7 @@ Get details for a single user.
                 + (object)
                     + type: `team` (string)
                     + id: `6dd0069e-45da-0ec4-911a-afb351d968cd`
-            + `external_rate` (object, nullable) - Only included with request parameter `includes=external_rate`
-                + amount: `123.30` (number)
-                + currency: `EUR` (string)
+            + `external_rate` (Money, nullable) - Only included with request parameter `includes=external_rate`
 
 
 ### users.listDaysOff [POST /users.listDaysOff]

--- a/apiary.apib
+++ b/apiary.apib
@@ -436,6 +436,7 @@ We list all backwards-compatible additions here. These are currently available i
 - We added `task.created`, `task.updated`, `task.completed`, `task.deleted` types to supported Webhook types.
 - We added `contact.updatedLinkToCompany` to supported Webhook types.
 - We added `includes` to the `companies.info` endpoint.
+- We added `includes` to the `users.info` endpoint.
 
 #### January 2024
 - We renamed `task_type` and `task_type_id` to `work_type` and `work_type_id` in `projects-v2/tasks.list`, `projects-v2/tasks.info`, `projects-v2/tasks.create` and `projects-v2/tasks.update`. The old names are still supported, but deprecated.
@@ -1303,6 +1304,7 @@ Get details for a single user.
 
     + Attributes (object)
         + id: `cb8da52a-ce89-4bf6-8f7e-8ee6cb85e3b5` (string, required)
+        + includes: `external_rate` (string, optional) - when used, the response will include `external_rate`
 
 + Response 200 (application/json)
 
@@ -1342,6 +1344,9 @@ Get details for a single user.
                 + (object)
                     + type: `team` (string)
                     + id: `6dd0069e-45da-0ec4-911a-afb351d968cd`
+            + `external_rate` (object, nullable) - Only included with request parameter `includes=external_rate`
+                + amount: `123.30` (number)
+                + currency: `EUR` (string)
 
 
 ### users.listDaysOff [POST /users.listDaysOff]

--- a/src/01-general/users.apib
+++ b/src/01-general/users.apib
@@ -160,9 +160,7 @@ Get details for a single user.
                 + (object)
                     + type: `team` (string)
                     + id: `6dd0069e-45da-0ec4-911a-afb351d968cd`
-            + `external_rate` (object, nullable) - Only included with request parameter `includes=external_rate`
-                + amount: `123.30` (number)
-                + currency: `EUR` (string)
+            + `external_rate` (Money, nullable) - Only included with request parameter `includes=external_rate`
 
 
 ### users.listDaysOff [POST /users.listDaysOff]

--- a/src/01-general/users.apib
+++ b/src/01-general/users.apib
@@ -120,6 +120,7 @@ Get details for a single user.
 
     + Attributes (object)
         + id: `cb8da52a-ce89-4bf6-8f7e-8ee6cb85e3b5` (string, required)
+        + includes: `external_rate` (string, optional) - when used, the response will include `external_rate`
 
 + Response 200 (application/json)
 
@@ -159,6 +160,9 @@ Get details for a single user.
                 + (object)
                     + type: `team` (string)
                     + id: `6dd0069e-45da-0ec4-911a-afb351d968cd`
+            + `external_rate` (object, nullable) - Only included with request parameter `includes=external_rate`
+                + amount: `123.30` (number)
+                + currency: `EUR` (string)
 
 
 ### users.listDaysOff [POST /users.listDaysOff]

--- a/src/changes-backwards-compatible.apib
+++ b/src/changes-backwards-compatible.apib
@@ -14,6 +14,7 @@ We list all backwards-compatible additions here. These are currently available i
 - We added `task.created`, `task.updated`, `task.completed`, `task.deleted` types to supported Webhook types.
 - We added `contact.updatedLinkToCompany` to supported Webhook types.
 - We added `includes` to the `companies.info` endpoint.
+- We added `includes` to the `users.info` endpoint.
 
 #### January 2024
 - We renamed `task_type` and `task_type_id` to `work_type` and `work_type_id` in `projects-v2/tasks.list`, `projects-v2/tasks.info`, `projects-v2/tasks.create` and `projects-v2/tasks.update`. The old names are still supported, but deprecated.


### PR DESCRIPTION
### Link to issue

https://teamleader.atlassian.net/browse/CON-29

### Description

- Document the external_rate includes "external_rate"
- Build documentation

### Feature flag

-

### Manual check

- Clone this repo
- Run `make preview`
- Open the generated html file
- Browse to the documentation for this endpoint, and verify if it matches the response

[Checklist for a thorough manual check](https://teamleader.atlassian.net/wiki/spaces/ENG/pages/3332735012/Manual+check+list)
