### PR TITLE
CON-28 add materials include to timeTracking info and list

### DIFF
--- a/apiary.apib
+++ b/apiary.apib
@@ -437,7 +437,7 @@ We list all backwards-compatible additions here. These are currently available i
 - We added `contact.updatedLinkToCompany` to supported Webhook types.
 - We added `includes` to the `companies.info` endpoint.
 - We added `includes` to the `users.info` endpoint.
-- We added `includes` to `timeTracking.list` and `timeTracking.info` endpoints.
+- We added `includes` to the `timeTracking.list` and `timeTracking.info` endpoints.
 
 #### January 2024
 - We renamed `task_type` and `task_type_id` to `work_type` and `work_type_id` in `projects-v2/tasks.list`, `projects-v2/tasks.info`, `projects-v2/tasks.create` and `projects-v2/tasks.update`. The old names are still supported, but deprecated.
@@ -7948,6 +7948,7 @@ Get a list of tracked time.
                           + `unit_price` (object)
                               + Include Money
                           + `quantity`: `5` (number)
+
 ### timeTracking.info [POST /timeTracking.info]
 
 Get information about tracked time.

--- a/apiary.apib
+++ b/apiary.apib
@@ -437,6 +437,7 @@ We list all backwards-compatible additions here. These are currently available i
 - We added `contact.updatedLinkToCompany` to supported Webhook types.
 - We added `includes` to the `companies.info` endpoint.
 - We added `includes` to the `users.info` endpoint.
+- We added `includes` to `timeTracking.list` and `timeTracking.info` endpoints.
 
 #### January 2024
 - We renamed `task_type` and `task_type_id` to `work_type` and `work_type_id` in `projects-v2/tasks.list`, `projects-v2/tasks.info`, `projects-v2/tasks.create` and `projects-v2/tasks.update`. The old names are still supported, but deprecated.
@@ -7907,6 +7908,8 @@ Get a list of tracked time.
                     + field: `starts_on`
                     + order: `asc`
         + page (Page, optional)
+        + includes: `materials` (string, optional) - when used, the response will include `materials`
+
 
 + Response 200 (application/json)
 
@@ -7936,7 +7939,15 @@ Get a list of tracked time.
                             + ticket
                     + id: `58f5b799-51c4-4eb9-8308-b1aa02e0a873` (string)
                 + invoiceable: true (boolean)
-
+                + `materials` (array) - Only included with request parameter `includes=materials`
+                      + (object)
+                          + `product` (object, nullable)
+                              + type: `product` (string)
+                              + id: `e2314517-3cab-4aa9-8471-450e73449040` (string)
+                          + `description`: `Product description` (string)
+                          + `unit_price` (object)
+                              + Include Money
+                          + `quantity`: `5` (number)
 ### timeTracking.info [POST /timeTracking.info]
 
 Get information about tracked time.
@@ -7945,6 +7956,7 @@ Get information about tracked time.
 
     + Attributes (object)
         + id: `6caeea11-aa83-4da9-9859-5b62bbf3a476` (string, required)
+        + includes: `materials` (string, optional) - when used, the response will include `materials`
 
 + Response 200 (application/json)
 
@@ -7982,6 +7994,15 @@ Get information about tracked time.
                 + invoice (object, nullable)
                     + type: `invoice` (string)
                     + id: `b2b4b2b4-4b2b-4b2b-4b2b-4b2b4b2b4b2b` (string)
+            + `materials` (array) - Only included with request parameter `includes=materials`
+                  + (object)
+                      + `product` (object, nullable)
+                          + type: `product` (string)
+                          + id: `e2314517-3cab-4aa9-8471-450e73449040` (string)
+                      + `description`: `Product description` (string)
+                      + `unit_price` (object)
+                          + Include Money
+                      + `quantity`: `5` (number)
         + meta (object)
             + updatable: true (boolean) - If true, the current user can update the entry even if it is locked
 

--- a/src/09-time-tracking/time-tracking.apib
+++ b/src/09-time-tracking/time-tracking.apib
@@ -94,6 +94,7 @@ Get a list of tracked time.
                           + `unit_price` (object)
                               + Include Money
                           + `quantity`: `5` (number)
+
 ### timeTracking.info [POST /timeTracking.info]
 
 Get information about tracked time.

--- a/src/09-time-tracking/time-tracking.apib
+++ b/src/09-time-tracking/time-tracking.apib
@@ -54,6 +54,8 @@ Get a list of tracked time.
                     + field: `starts_on`
                     + order: `asc`
         + page (Page, optional)
+        + includes: `materials` (string, optional) - when used, the response will include `materials`
+
 
 + Response 200 (application/json)
 
@@ -83,7 +85,15 @@ Get a list of tracked time.
                             + ticket
                     + id: `58f5b799-51c4-4eb9-8308-b1aa02e0a873` (string)
                 + invoiceable: true (boolean)
-
+                + `materials` (array) - Only included with request parameter `includes=materials`
+                      + (object)
+                          + `product` (object, nullable)
+                              + type: `product` (string)
+                              + id: `e2314517-3cab-4aa9-8471-450e73449040` (string)
+                          + `description`: `Product description` (string)
+                          + `unit_price` (object)
+                              + Include Money
+                          + `quantity`: `5` (number)
 ### timeTracking.info [POST /timeTracking.info]
 
 Get information about tracked time.
@@ -92,6 +102,7 @@ Get information about tracked time.
 
     + Attributes (object)
         + id: `6caeea11-aa83-4da9-9859-5b62bbf3a476` (string, required)
+        + includes: `materials` (string, optional) - when used, the response will include `materials`
 
 + Response 200 (application/json)
 
@@ -129,6 +140,15 @@ Get information about tracked time.
                 + invoice (object, nullable)
                     + type: `invoice` (string)
                     + id: `b2b4b2b4-4b2b-4b2b-4b2b-4b2b4b2b4b2b` (string)
+            + `materials` (array) - Only included with request parameter `includes=materials`
+                  + (object)
+                      + `product` (object, nullable)
+                          + type: `product` (string)
+                          + id: `e2314517-3cab-4aa9-8471-450e73449040` (string)
+                      + `description`: `Product description` (string)
+                      + `unit_price` (object)
+                          + Include Money
+                      + `quantity`: `5` (number)
         + meta (object)
             + updatable: true (boolean) - If true, the current user can update the entry even if it is locked
 

--- a/src/changes-backwards-compatible.apib
+++ b/src/changes-backwards-compatible.apib
@@ -15,7 +15,7 @@ We list all backwards-compatible additions here. These are currently available i
 - We added `contact.updatedLinkToCompany` to supported Webhook types.
 - We added `includes` to the `companies.info` endpoint.
 - We added `includes` to the `users.info` endpoint.
-- We added `includes` to `timeTracking.list` and `timeTracking.info` endpoints.
+- We added `includes` to the `timeTracking.list` and `timeTracking.info` endpoints.
 
 #### January 2024
 - We renamed `task_type` and `task_type_id` to `work_type` and `work_type_id` in `projects-v2/tasks.list`, `projects-v2/tasks.info`, `projects-v2/tasks.create` and `projects-v2/tasks.update`. The old names are still supported, but deprecated.

--- a/src/changes-backwards-compatible.apib
+++ b/src/changes-backwards-compatible.apib
@@ -15,6 +15,7 @@ We list all backwards-compatible additions here. These are currently available i
 - We added `contact.updatedLinkToCompany` to supported Webhook types.
 - We added `includes` to the `companies.info` endpoint.
 - We added `includes` to the `users.info` endpoint.
+- We added `includes` to `timeTracking.list` and `timeTracking.info` endpoints.
 
 #### January 2024
 - We renamed `task_type` and `task_type_id` to `work_type` and `work_type_id` in `projects-v2/tasks.list`, `projects-v2/tasks.info`, `projects-v2/tasks.create` and `projects-v2/tasks.update`. The old names are still supported, but deprecated.


### PR DESCRIPTION
Add materials to includes of two endpoints 
- `timeTracking.list`
- `timeTracking.info`

**Test instruction**
- Build the `apiary.apib` file
- Check that the documentation for both `timeTracking.list` and `timeTracking.info`
- Check that the API response will include materials details when materials include exist `?includes=materials` 
- Check that the structure match the documentation