### PR TITLE
Document project po number

### DIFF
--- a/apiary.apib
+++ b/apiary.apib
@@ -426,6 +426,9 @@ We consider the following changes to be backwards-incompatible:
 We list all backwards-compatible additions here. These are currently available in all published versions.
 (There is also a [list of backwards-incompatible upgrades](#changelog) available, but those only apply if you [upgrade your API version](#upgrading-your-api-version).)
 
+#### May 2024
+- We added `purchase_order_number` to `projects-v2/projects.info`, `projects-v2/projects.create` and `projects-v2/projects.update`.
+
 #### April 2024
 - The meeting property `project` returned in `meetings.list` and `meetings.info` can now be an id of a `nextgenProject` as well.
 

--- a/apiary.apib
+++ b/apiary.apib
@@ -6262,6 +6262,7 @@ Returns all the information of a single project.
             + `margin_percentage` (number, nullable) - `null` if the user does not have access to "Costs on projects"
             + `start_date`: `2022-02-23` (string, nullable)
             + `end_date`: `2022-02-28` (string, nullable)
+            + `purchase_order_number`: `000023` (string, nullable)
             + `company_entity` (object, nullable)
                 + `type`: `department` (string)
                 + `id`: `0d0dec5a-7096-4009-be37-07eab117db07` (string)
@@ -6345,6 +6346,7 @@ Create a new project. Only `title` is required. All the other fields are optiona
         + `fixed_price` (Money, optional) - Must be higher than or equal to zero, and lower than 100000000000 (100 billion). Only allowed for `fixed_price` billing method. Currently only EUR is supported
         + `start_date`: `2022-02-23` (string, optional) - Should not be after end_date if provided
         + `end_date`: `2022-02-28` (string, optional) - Should not be before start_date if provided
+        + `purchase_order_number`: `000023` (string, nullable)
         + `company_entity_id`: `0d0dec5a-7096-4009-be37-07eab117db07` (string, optional)
         + `color`: `#00B2B2` (enum[string], optional)
             + Members
@@ -6415,6 +6417,7 @@ Update a project. All attributes except for `id` are optional. Providing `null` 
         + `fixed_price` (Money, nullable) - Must be higher than or equal to zero, and lower than 100000000000 (100 billion). Only allowed for `fixed_price` billing method. Currently only EUR is supported
         + `start_date`: `2022-02-23` (string, nullable) - Should not be after end_date if provided
         + `end_date`: `2022-02-28` (string, nullable) - Should not be before start_date if provided
+        + `purchase_order_number`: `000023` (string, nullable)
         + `company_entity_id`: `0d0dec5a-7096-4009-be37-07eab117db07` (string, nullable, optional)
         + `color`: `#00B2B2` (enum[string])
             + Members

--- a/apiary.apib
+++ b/apiary.apib
@@ -6349,7 +6349,7 @@ Create a new project. Only `title` is required. All the other fields are optiona
         + `fixed_price` (Money, optional) - Must be higher than or equal to zero, and lower than 100000000000 (100 billion). Only allowed for `fixed_price` billing method. Currently only EUR is supported
         + `start_date`: `2022-02-23` (string, optional) - Should not be after end_date if provided
         + `end_date`: `2022-02-28` (string, optional) - Should not be before start_date if provided
-        + `purchase_order_number`: `000023` (string, nullable)
+        + `purchase_order_number`: `000023` (string, optional)
         + `company_entity_id`: `0d0dec5a-7096-4009-be37-07eab117db07` (string, optional)
         + `color`: `#00B2B2` (enum[string], optional)
             + Members

--- a/src/12-nextgen-projects/projects.apib
+++ b/src/12-nextgen-projects/projects.apib
@@ -222,6 +222,7 @@ Returns all the information of a single project.
             + `margin_percentage` (number, nullable) - `null` if the user does not have access to "Costs on projects"
             + `start_date`: `2022-02-23` (string, nullable)
             + `end_date`: `2022-02-28` (string, nullable)
+            + `purchase_order_number`: `000023` (string, nullable)
             + `company_entity` (object, nullable)
                 + `type`: `department` (string)
                 + `id`: `0d0dec5a-7096-4009-be37-07eab117db07` (string)
@@ -305,6 +306,7 @@ Create a new project. Only `title` is required. All the other fields are optiona
         + `fixed_price` (Money, optional) - Must be higher than or equal to zero, and lower than 100000000000 (100 billion). Only allowed for `fixed_price` billing method. Currently only EUR is supported
         + `start_date`: `2022-02-23` (string, optional) - Should not be after end_date if provided
         + `end_date`: `2022-02-28` (string, optional) - Should not be before start_date if provided
+        + `purchase_order_number`: `000023` (string, nullable)
         + `company_entity_id`: `0d0dec5a-7096-4009-be37-07eab117db07` (string, optional)
         + `color`: `#00B2B2` (enum[string], optional)
             + Members
@@ -375,6 +377,7 @@ Update a project. All attributes except for `id` are optional. Providing `null` 
         + `fixed_price` (Money, nullable) - Must be higher than or equal to zero, and lower than 100000000000 (100 billion). Only allowed for `fixed_price` billing method. Currently only EUR is supported
         + `start_date`: `2022-02-23` (string, nullable) - Should not be after end_date if provided
         + `end_date`: `2022-02-28` (string, nullable) - Should not be before start_date if provided
+        + `purchase_order_number`: `000023` (string, nullable)
         + `company_entity_id`: `0d0dec5a-7096-4009-be37-07eab117db07` (string, nullable, optional)
         + `color`: `#00B2B2` (enum[string])
             + Members

--- a/src/12-nextgen-projects/projects.apib
+++ b/src/12-nextgen-projects/projects.apib
@@ -306,7 +306,7 @@ Create a new project. Only `title` is required. All the other fields are optiona
         + `fixed_price` (Money, optional) - Must be higher than or equal to zero, and lower than 100000000000 (100 billion). Only allowed for `fixed_price` billing method. Currently only EUR is supported
         + `start_date`: `2022-02-23` (string, optional) - Should not be after end_date if provided
         + `end_date`: `2022-02-28` (string, optional) - Should not be before start_date if provided
-        + `purchase_order_number`: `000023` (string, nullable)
+        + `purchase_order_number`: `000023` (string, optional)
         + `company_entity_id`: `0d0dec5a-7096-4009-be37-07eab117db07` (string, optional)
         + `color`: `#00B2B2` (enum[string], optional)
             + Members

--- a/src/changes-backwards-compatible.apib
+++ b/src/changes-backwards-compatible.apib
@@ -4,6 +4,9 @@
 We list all backwards-compatible additions here. These are currently available in all published versions.
 (There is also a [list of backwards-incompatible upgrades](#changelog) available, but those only apply if you [upgrade your API version](#upgrading-your-api-version).)
 
+#### May 2024
+- We added `purchase_order_number` to `projects-v2/projects.info`, `projects-v2/projects.create` and `projects-v2/projects.update`.
+
 #### April 2024
 - The meeting property `project` returned in `meetings.list` and `meetings.info` can now be an id of a `nextgenProject` as well.
 


### PR DESCRIPTION
#### May 2024
- We added `purchase_order_number` to `projects-v2/projects.info`, `projects-v2/projects.create` and `projects-v2/projects.update`.