### PR TITLE
CON-408 include a note about uuid migration under API Evolution section

### DIFF
--- a/apiary.apib
+++ b/apiary.apib
@@ -1099,6 +1099,9 @@ You can follow our API progress and ongoing proposals via our [API Blueprint Git
 For customers that are still using legacy API v1 version which was deprecated in 2019, keep in mind that we will make all of the endpoints unavailable in 2024:
  - Active deprecation mode: June 1, 2024
  - Final sunsetting of API v1: August 1, 2024
+> **Note:**
+>
+> + API uses UUIDs for all resources. If you need help to convert API v1 integer ids to UUIDs, please check this [guide](https://support.focus.teamleader.eu/hc/en-150/articles/26981214932625-Migrating-from-legacy-API-v1-Transitioning-from-Integer-IDs-to-UUIDs).
 
 [Contact Support](https://support.focus.teamleader.eu/support/tickets/new)
 

--- a/src/roadmap.apib
+++ b/src/roadmap.apib
@@ -11,5 +11,8 @@
 For customers that are still using legacy API v1 version which was deprecated in 2019, keep in mind that we will make all of the endpoints unavailable in 2024:
  - Active deprecation mode: June 1, 2024
  - Final sunsetting of API v1: August 1, 2024
+> **Note:**
+>
+> + API uses UUIDs for all resources. If you need help to convert API v1 integer ids to UUIDs, please check this [guide](https://support.focus.teamleader.eu/hc/en-150/articles/26981214932625-Migrating-from-legacy-API-v1-Transitioning-from-Integer-IDs-to-UUIDs).
 
 [Contact Support](https://support.focus.teamleader.eu/support/tickets/new)


### PR DESCRIPTION
https://teamleader.atlassian.net/browse/CON-408

Add a brief not to refer to uuid migration [article](https://support.focus.teamleader.eu/hc/en-150/articles/26981214932625-Migrating-from-legacy-API-v1-Transitioning-from-Integer-IDs-to-UUIDs) 