### PR TITLE
[CON-353] Add json content type headers to 201 responses

### DIFF
--- a/apiary.apib
+++ b/apiary.apib
@@ -8252,7 +8252,7 @@ Add tracked time.
         + invoiceable: true (boolean, optional)
         + user_id: `87982c96-f2fe-4b05-838c-ff42c0525758` (string, optional) - To add tracked time for a different user.
 
-+ Response 201
++ Response 201 (application/json)
 
     + Attributes (object)
         + data (object)
@@ -8300,7 +8300,7 @@ Start a new timer based on previously tracked time.
         + id: `06dfa08a-b769-4005-a912-45ab885c5737` (string, required)
         + started_at: `2017-04-26T10:01:49+00:00` (string, optional) - If not provided, current time will be used
 
-+ Response 201
++ Response 201 (application/json)
 
     + Attributes (object)
         + data (object)
@@ -8373,7 +8373,7 @@ Start a new timer.
             + id: `29ff471c-7d8f-40d5-8c95-9a9cab841e65` (string, required)
         + invoiceable: true (boolean, optional)
 
-+ Response 201
++ Response 201 (application/json)
 
     + Attributes (object)
         + data (object)

--- a/src/09-time-tracking/time-tracking.apib
+++ b/src/09-time-tracking/time-tracking.apib
@@ -203,7 +203,7 @@ Add tracked time.
         + invoiceable: true (boolean, optional)
         + user_id: `87982c96-f2fe-4b05-838c-ff42c0525758` (string, optional) - To add tracked time for a different user.
 
-+ Response 201
++ Response 201 (application/json)
 
     + Attributes (object)
         + data (object)
@@ -251,7 +251,7 @@ Start a new timer based on previously tracked time.
         + id: `06dfa08a-b769-4005-a912-45ab885c5737` (string, required)
         + started_at: `2017-04-26T10:01:49+00:00` (string, optional) - If not provided, current time will be used
 
-+ Response 201
++ Response 201 (application/json)
 
     + Attributes (object)
         + data (object)

--- a/src/09-time-tracking/timers.apib
+++ b/src/09-time-tracking/timers.apib
@@ -53,7 +53,7 @@ Start a new timer.
             + id: `29ff471c-7d8f-40d5-8c95-9a9cab841e65` (string, required)
         + invoiceable: true (boolean, optional)
 
-+ Response 201
++ Response 201 (application/json)
 
     + Attributes (object)
         + data (object)


### PR DESCRIPTION
### Description

Add json content type headers to 201 responses, these were missing for these endpoints, and this is problematic when converting to OpenAPI
