### PR TITLE
Add ubl/peppol_bis_3 to the list of allowed formats in invoices.download

### DIFF
--- a/apiary.apib
+++ b/apiary.apib
@@ -434,6 +434,7 @@ We list all backwards-compatible additions here. These are currently available i
 
 #### January 2025
 - We added `periodicity` to the quotation line items in `quotations.info`, `quotations.create` and `quotations.update`.
+- We added `ubl/peppol_bis_3` to the list of allowed formats in `invoices.download`.
 
 #### December 2024
 - We added `initial_time_tracked`, `initial_price`, `initial_cost`, `initial_amount_billed`, and `initial_amount_paid` to `projects-v2/projects.create`. "Initial" values can be used when importing project data.
@@ -4700,6 +4701,7 @@ Download an invoice in a specific format.
             + Members
                 + pdf
                 + `ubl/e-fff`
+                + `ubl/peppol_bis_3`
 
 + Response 200 (application/json)
 

--- a/src/05-invoicing/invoices.apib
+++ b/src/05-invoicing/invoices.apib
@@ -262,6 +262,7 @@ Download an invoice in a specific format.
             + Members
                 + pdf
                 + `ubl/e-fff`
+                + `ubl/peppol_bis_3`
 
 + Response 200 (application/json)
 

--- a/src/changes-backwards-compatible.apib
+++ b/src/changes-backwards-compatible.apib
@@ -6,6 +6,7 @@ We list all backwards-compatible additions here. These are currently available i
 
 #### January 2025
 - We added `periodicity` to the quotation line items in `quotations.info`, `quotations.create` and `quotations.update`.
+- We added `ubl/peppol_bis_3` to the list of allowed formats in `invoices.download`.
 
 #### December 2024
 - We added `initial_time_tracked`, `initial_price`, `initial_cost`, `initial_amount_billed`, and `initial_amount_paid` to `projects-v2/projects.create`. "Initial" values can be used when importing project data.


### PR DESCRIPTION
We added 'ubl/peppol_bis_3' to the list of available formats in invoices.download